### PR TITLE
fix(config): bake keycloak-config.json env-template (not empty {})

### DIFF
--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -5,11 +5,12 @@
 #   2. pnpm install --no-frozen-lockfile (pnpm-lock.yaml ist out-of-sync,
 #      GH Actions setzt CI=true -> pnpm install defaultet zu --frozen-lockfile)
 #   3. pnpm run build (tsc && vite build -> dist/)
-#   4. Dummy keycloak-config.json (Cluster mountet ConfigMap zur Laufzeit drueber,
-#      Dockerfile erwartet die Datei aber zur Build-Zeit via ADD)
-#   5. docker/build-push-action -> ghcr.io/vfeeg-development/vfeeg-web
-#   6. Build-Provenance-Attestation
-#   7. dispatch-deploy -> repository_dispatch deploy-web ans Platform-Repo
+#   4. docker/build-push-action -> ghcr.io/vfeeg-development/vfeeg-web
+#      (keycloak-config.json ist als Caddy-Env-Template eingecheckt und wird
+#      via `ADD keycloak-config.json /srv` gebacken; Caddy rendert es zur
+#      Laufzeit aus KEYCLOAK_URL/_REALM/_CLIENT_ID — kein Runtime-Mount noetig)
+#   5. Build-Provenance-Attestation
+#   6. dispatch-deploy -> repository_dispatch deploy-web ans Platform-Repo
 #
 # STUFE 3 (2026-06-18): Development-Tier (ADR-0005). Image pusht nach
 # `ghcr.io/vfeeg-development/vfeeg-web` (Login via VFEEG_DEV_PUSH_PAT), und der
@@ -79,13 +80,6 @@ jobs:
         # vite build direkt aufrufen - vite kompiliert TS, ohne strict type-check.
         # So sehen wir, ob's neben tsc noch weitere Build-Blocker gibt.
         run: pnpm exec vite build
-
-      - name: Stub keycloak-config.json for Docker build context
-        run: |
-          # Dockerfile macht `ADD keycloak-config.json /srv`. Im Cluster wird
-          # die Datei per ConfigMap-Mount (eegfaktura-web-keycloak) ueber-
-          # schrieben, deshalb reicht eine leere JSON.
-          echo '{}' > keycloak-config.json
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta

--- a/keycloak-config.json
+++ b/keycloak-config.json
@@ -1,0 +1,12 @@
+{
+  "app" : {
+    "realm": {{ with (env "KEYCLOAK_REALM") }}{{ printf "%q" . }}{{ else }}{{ printf "%q" "EEGFaktura" }}{{ end }},
+    "auth-server-url": {{ with (env "KEYCLOAK_URL") }}{{ printf "%q" . }}{{ else }}{{ printf "%q" "http://localhost:7080/" }}{{ end }},
+    "ssl-required": "external",
+    "resource": {{ with (env "KEYCLOAK_CLIENT_ID") }}{{ printf "%q" . }}{{ else }}{{ printf "%q" "at.ourproject.vfeeg.app" }}{{ end }},
+    "public-client": true,
+    "verify-token-audience": true,
+    "use-resource-role-mappings": true,
+    "confidential-port": 0
+  }
+}


### PR DESCRIPTION
## Problem

The current CI bakes a literal `{}` as `/srv/keycloak-config.json` (the file Caddy serves at `/config/keycloak-config.json`), assuming the cluster mounts a ConfigMap over it at runtime. **Prod has no such mount.** The working `v0.2.36` image bakes a **Caddy env-template** that renders the config from `KEYCLOAK_URL` / `KEYCLOAK_REALM` / `KEYCLOAK_CLIENT_ID` at request time.

With `{}`, the SPA reads `app["auth-server-url"] = undefined` and crashes (`Cannot read properties of undefined`). Verified by exporting both images: v0.2.36's `/srv/keycloak-config.json` is the template; v1.0.0's is `{}`.

## Fix

Restore the original, proven mechanism:
- Check in `keycloak-config.json` as the Caddy env-template (extracted verbatim from v0.2.36, `app` key; local-default `resource` corrected to `at.ourproject.vfeeg.app`). `Dockerfile` already `ADD`s it to `/srv`.
- Drop the CI "Stub keycloak-config.json" step.

No ConfigMap, no prod-manifest change. In prod it renders from the existing deployment env vars (exactly as v0.2.36 did). Dev that still mounts a ConfigMap over `/srv/keycloak-config.json` is unaffected — the mount shadows the baked file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)