### PR TITLE
fix(period): default to current date, not hardcoded 2026-02-01

### DIFF
--- a/src/store/hook/Eeg.provider.tsx
+++ b/src/store/hook/Eeg.provider.tsx
@@ -145,7 +145,7 @@ export const EegProvider: FC<{ children: ReactNode }> = ({children}) => {
   // }, [eeg]);
 
   const getCurrentPeriod = async (eeg: Eeg | undefined) => {
-    const currentDate = new Date(2026, 1, 1) //new Date(Date.now())
+    const currentDate = new Date(Date.now())
     let period = "Y"
     let segment = 0
     if (eeg) {


### PR DESCRIPTION
## Symptom
Beim Öffnen einer EEG steht die Periode/Abrechnungsperiode immer auf **Q1 2026 (Jän–März)** statt auf der aktuellen Periode — unabhängig vom heutigen Datum.

## Ursache
`src/store/hook/Eeg.provider.tsx` `getCurrentPeriod()` pinnt das Datum hart:
```ts
const currentDate = new Date(2026, 1, 1) //new Date(Date.now())
```
`new Date(2026, 1, 1)` = **01.02.2026** (JS-Monat 1 = Februar) → Default-Segment rechnet immer auf Q1/2026. Eingeschleppt durch Commit `f019efe` ("fix", 2026-06-12) — ein vergessener Debug-Pin; davor wurde `Date.now()` genutzt. Kam mit dem source-built **v1.0.0**-Image in Prod (vorher korrekt).

## Fix
Ein-Zeilen-Revert auf das Live-Datum:
```ts
const currentDate = new Date(Date.now())
```
Danach defaultet eine Quartals-EEG am 28.06.2026 korrekt auf Q2 2026, monatlich auf Juni 2026 usw. Keine weitere Logik betroffen; restliche `new Date(2026,…)`-Treffer sind nur Tests/Defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)