### PR TITLE
fix(notifications): 24h-Zeitformat (HH:mm:ss) statt 12h ohne AM/PM

### DIFF
--- a/src/components/notification/NotificationItem.component.tsx
+++ b/src/components/notification/NotificationItem.component.tsx
@@ -48,7 +48,7 @@ const NotificationItemComponent: FC<NotificationItemComponentProps> = ({type, pr
         </IonCardContent>
         <IonFooter>
           <div style={{display: "flex", flexFlow: "row", columnGap: "24px", alignItems: "center"}}>
-            <div className="notification-date">{moment(date).format("dd, MMM Do YYYY, h:mm:ss")}</div>
+            <div className="notification-date">{moment(date).format("dd, MMM Do YYYY, HH:mm:ss")}</div>
             <div>{getProcessId()}</div>
           </div>
         </IonFooter>


### PR DESCRIPTION
## Symptom
Messages-Zeit zeigt PM-Zeiten falsch/zweideutig (z. B. wird 21:41 als „9:41" angezeigt).

## Ursache
`NotificationItem.component.tsx` formatiert mit `moment(date).format("dd, MMM Do YYYY, h:mm:ss")` — `h` = 12-Stunden **ohne** `a`/`A` (kein AM/PM).

## Fix
`h:mm:ss` → `HH:mm:ss` (24-Stunden).

Hinweis: Der zusätzliche **+2h-Versatz** ist ein **separater Backend-Bug** (Notification-Zeit als lokale Zeit mit `Z`/UTC serialisiert) — Fix in [eegfaktura-backend#6](https://github.com/eegfaktura/eegfaktura-backend/pull/6). Erst beide zusammen ergeben die korrekte Anzeige.

🤖 Generated with [Claude Code](https://claude.com/claude-code)