### PR TITLE
docs: translate CHANGELOG.md to English

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,33 +1,33 @@
 # Changelog
 
-Alle nennenswerten Änderungen an **eegfaktura-web (React-Frontend)** werden hier dokumentiert.
+All notable changes to **eegfaktura-web (React frontend)** are documented here.
 
-Das Format orientiert sich an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/),
-die Versionierung an den Deployment-Release-Tags. Detail-Diffs bleiben im `git log`;
-dieser Changelog hebt die für Überblick und Betrieb relevanten Änderungen hervor.
+The format is based on [Keep a Changelog](https://keepachangelog.com/), and
+versioning follows the deployment release tags. Detailed diffs stay in the `git log`;
+this changelog highlights the changes relevant for overview and operations.
 
 ## [Unreleased]
 
 ## [1.0.2] – 2026-06-28
 
 ### Fixed
-- Benachrichtigungen: 24-Stunden-Zeitformat (`HH:mm:ss`) statt 12h ohne AM/PM. (#56)
+- Notifications: 24-hour time format (`HH:mm:ss`) instead of 12h without AM/PM. (#56)
 
 ## [1.0.1] – 2026-06-28
 
 ### Fixed
-- Abrechnungsperiode: Standard ist wieder das aktuelle Datum statt eines
-  hartkodierten `2026-02-01`. (#55)
+- Billing period: defaults to the current date again instead of a hardcoded
+  `2026-02-01`. (#55)
 
 ## [1.0.0] – 2026-06-28
 
-Erster vollständig aus öffentlichem Quellcode gebauter Produktiv-Release.
+First production release built entirely from public source.
 
 ### Fixed
-- Konfiguration: `keycloak-config.json` wird als Env-Template ins Image gebacken
-  statt als leeres `{}`. (#54)
+- Configuration: `keycloak-config.json` is baked into the image as an env template
+  instead of an empty `{}`. (#54)
 
 ### Changed
-- CI: Stage-1 Source-Build; Push in den Development-Tier der Registry mit
-  Auto-Rollout-Bridge (dispatch-deploy). (#51, #52)
-- README mit Service-Überblick und Tech-Stack ergänzt. (#53)
+- CI: stage-1 source build; push to the registry's development tier with an
+  auto-rollout bridge (dispatch-deploy). (#51, #52)
+- Added README with service overview and tech stack. (#53)


### PR DESCRIPTION
Translates the recently added CHANGELOG.md to English for consistency with the READMEs, the org profile and eegfaktura-docs. Content unchanged.