### PR TITLE
fix(dashboard): NaN € in Finanzen bei Tarif ohne freeKWh/baseFee

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ this changelog highlights the changes relevant for overview and operations.
 
 ## [Unreleased]
 
+## [1.0.3] – 2026-06-29
+
+### Fixed
+- Dashboard finances: "Verkauft" and "Marge EEG" no longer show `NaN €` when an
+  active tariff leaves the optional fields `freeKWh` (VZP) or `baseFee` (EZP)
+  empty — they are now treated as `0`, matching `TariffHelper`. (#59)
+
 ## [1.0.2] – 2026-06-28
 
 ### Fixed

--- a/src/components/dashboard/EnergyOverview.component.tsx
+++ b/src/components/dashboard/EnergyOverview.component.tsx
@@ -93,9 +93,9 @@ const EnergyOverviewComponent: FC<OverviewComponentProps> = ({consumed, produced
       const tariff = rates[m.tariff_id]
       if (tariff && tariff.type) {
         if (tariff.type === "EZP") {
-          return (Math.max(utilization * (tariff.centPerKWh || 0), 0) / 100) + Number(tariff.baseFee)
+          return (Math.max(utilization * (tariff.centPerKWh || 0), 0) / 100) + Number(tariff.baseFee || 0)
         } else if (tariff.type === 'VZP') {
-          return Math.max(utilization - Number(tariff.freeKWh), 0) * (tariff.centPerKWh || 0) / 100 * getDiscountFactor(tariff.discount)
+          return Math.max(utilization - Number(tariff.freeKWh || 0), 0) * (tariff.centPerKWh || 0) / 100 * getDiscountFactor(tariff.discount)
         }
       }
     }


### PR DESCRIPTION
## Problem

Im Dashboard zeigen **Verkauft** und **Marge EEG** „NaN €" (Kunden-Meldungen 29.06.). Betrifft mehrere EEGs, tritt datenabhängig auf.

## Ursache

`meterCash()` in `EnergyOverview.component.tsx` liest `Number(tariff.freeKWh)` (VZP) bzw. `Number(tariff.baseFee)` (EZP) **ohne Fallback**. Beide Felder sind optional. Ist das Feld leer → `Number(undefined) = NaN` → `Math.max(util - NaN, 0) = NaN`. Ein einziger aktiver Verbrauchs-ZP mit einem VZP-Tarif **ohne „Inklusive kWh"** vergiftet `consumerCash`, also `taken.money` und damit auch die Marge (`taken − spent`).

Es ist **keine kaputte Tarifzuordnung** — der Tarif ist zugeordnet und vorhanden, nur das optionale Feld ist leer. Die echte Abrechnung (`TariffHelper.ts`) behandelt „leer = 0" bereits korrekt; nur dieses Dashboard-Widget wich ab.

## Fix

`freeKWh` und `baseFee` mit `|| 0` absichern — identisch zum bereits vorhandenen `centPerKWh || 0` daneben und zur Semantik in `TariffHelper`. Tarife mit gesetzten Feldern ändern sich nicht.

```diff
- Number(tariff.baseFee)
+ Number(tariff.baseFee || 0)
- Number(tariff.freeKWh)
+ Number(tariff.freeKWh || 0)
```

`tsc --noEmit` sauber. Geplant als Release **v1.0.3**.