### PR TITLE
feat(meter-chart): Tagesansicht der Energiedaten eines Zählpunkts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ this changelog highlights the changes relevant for overview and operations.
 
 ## [Unreleased]
 
+### Added
+- Metering point energy chart: a day view (`D`) showing the day's 15-minute
+  values as a line chart (EEG vs EVU), with day-by-day navigation. Pulls raw
+  interval data from the energystore `/eeg/v2/{ec}/raw` endpoint. Ported from an
+  AGPL-3.0 sibling deployment.
+
+### Changed
+- Chart period switch now defaults to the current date's segment instead of the
+  EEG period end (which often has no data yet).
+
 ## [1.0.3] – 2026-06-29
 
 ### Fixed

--- a/src/components/dashboard/ChartProperties.component.tsx
+++ b/src/components/dashboard/ChartProperties.component.tsx
@@ -49,7 +49,10 @@ const ChartProperties:FC<ChartPropertiesProps> = ({selectedPeriod, periods, onDi
   }
 
   const getSelectedPeriod = (periodType: ReportType) => {
-    return getPeriodValue(transformPeriodFromSegment(periodType, selectedPeriod, moment(periods.end.substring(0,19), "DD.MM.YYYY HH:mm:ss")/*moment()*/))
+    // Default segment when switching period: current date, NOT the EEG period
+    // end. periods.end is typically the year end → the switch would land in a
+    // segment that has no data yet. (Matches prod behaviour.)
+    return getPeriodValue(transformPeriodFromSegment(periodType, selectedPeriod, moment()))
   }
 
   const getPeroidFromString = (periodString: string): SelectedPeriod => {
@@ -78,6 +81,7 @@ const ChartProperties:FC<ChartPropertiesProps> = ({selectedPeriod, periods, onDi
       case 'YH': return selectedPeriod.type === 'YH';
       case 'YQ': return selectedPeriod.type === 'YQ';
       case 'YM': return selectedPeriod.type === 'YM';
+      case 'D': return selectedPeriod.type === 'D';
     }
   }
 

--- a/src/components/participantPane/MeterChart.component.tsx
+++ b/src/components/participantPane/MeterChart.component.tsx
@@ -1,14 +1,15 @@
 import React, {FC, useEffect, useState} from "react";
 import MeterChartNavbarComponent from "./MeterChartNavbar.component";
-import {Bar, BarChart, CartesianGrid, Legend, ResponsiveContainer, Tooltip, XAxis, YAxis} from "recharts";
+import {Bar, BarChart, CartesianGrid, Legend, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis} from "recharts";
 import {
   EnergySeries,
   MeterEnergySeries,
   MeterReport,
   ParticipantReport,
+  RawDataResult,
   SelectedPeriod
 } from "../../models/energy.model";
-import {calcXAxisName} from "../../util/Helper.util";
+import {calcXAxisName, dayOfYearToDate} from "../../util/Helper.util";
 import {Metering} from "../../models/meteringpoint.model";
 import {EegParticipant} from "../../models/members.model";
 import {transformMeterReportToEnergySeries} from "../../util/ReportHelper";
@@ -35,38 +36,72 @@ const MeterChartComponent: FC<MeterChartComponentProps> = ({tenant, report, acti
   //   return false
   // })
 
-  const updateSeries = async (selectedPeriod: SelectedPeriod) => {
-    if (selectedParticipant && selectedMeter) {
-      return Api.energyService.fetchReportV2(tenant, selectedPeriod.year, selectedPeriod.segment, selectedPeriod.type,
-        [{
-          participantId: selectedParticipant.id,
-          meters: [
-            {
-              meterId: selectedMeter.meteringPoint,
-              meterDir: selectedMeter.direction,
-              from: selectedMeter.participantState
-                ? new Date(selectedMeter.participantState.activeSince).getTime()
-                : new Date().getTime(),
-              until: selectedMeter.participantState
-                ? new Date(selectedMeter.participantState.inactiveSince).getTime()
-                : new Date().getTime(),
-            } as MeterReport]
-        } as ParticipantReport])
-        .then(res => {
-          if (res.participantReports.length !== 1) {
-            throw new Error("Keine Daten gefunden")
-          }
-          return res.participantReports[0]
-        })
-        .then(rep => transformMeterReportToEnergySeries(rep.meters[0]))
-        .then(s => {
-          return {
-            series: s,
-            period: selectedPeriod
-          } as MeterEnergySeries
-        })
+  const transformRawToEnergySeries = (raw: RawDataResult): EnergySeries[] => {
+    // 96 × 15-min slots, indexed 0..95 by minutes-of-day. Missing slots stay 0.
+    const slots: EnergySeries[] = Array.from({length: 96}, (_, i) => ({
+      segmentIdx: i, allocated: 0, consumed: 0
+    }))
+    raw.data.forEach(d => {
+      const date = new Date(d.ts)
+      const slot = date.getHours() * 4 + Math.floor(date.getMinutes() / 15)
+      if (slot < 0 || slot > 95) return
+      if (raw.direction === 'CONSUMPTION') {
+        // value = [Consumed, Allocated, Distributed] → allocated=Distributed (EEG), consumed=Consumed-Distributed (EVU)
+        const consumed = d.value[0] ?? 0
+        const distributed = d.value[2] ?? 0
+        slots[slot].allocated = distributed
+        slots[slot].consumed = Math.max(0, consumed - distributed)
+      } else {
+        // value = [Produced, Allocation] → allocated=Produced-Allocation (eigen/extern), consumed=Allocation (an EEG)
+        const produced = d.value[0] ?? 0
+        const allocation = d.value[1] ?? 0
+        slots[slot].allocated = Math.max(0, produced - allocation)
+        slots[slot].consumed = allocation
+      }
+    })
+    return slots
+  }
+
+  const fetchDaySeries = async (selectedPeriod: SelectedPeriod): Promise<MeterEnergySeries> => {
+    const dayStart = dayOfYearToDate(selectedPeriod.year, selectedPeriod.segment)
+    dayStart.setHours(0, 0, 0, 0)
+    const dayEnd = new Date(dayStart.getTime() + 24 * 60 * 60 * 1000 - 1)
+    const raw = await Api.energyService.fetchRawV2(tenant, dayStart.getTime(), dayEnd.getTime(),
+      [selectedMeter.meteringPoint])
+    const meterRaw = raw[selectedMeter.meteringPoint]
+    const series = meterRaw ? transformRawToEnergySeries(meterRaw) :
+      Array.from({length: 96}, (_, i) => ({segmentIdx: i, allocated: 0, consumed: 0} as EnergySeries))
+    return {series, period: selectedPeriod}
+  }
+
+  const updateSeries = async (selectedPeriod: SelectedPeriod): Promise<MeterEnergySeries> => {
+    if (!selectedParticipant || !selectedMeter) return activeEnergySeries
+    if (selectedPeriod.type === 'D') {
+      return fetchDaySeries(selectedPeriod)
     }
-    return activeEnergySeries
+    return Api.energyService.fetchReportV2(tenant, selectedPeriod.year, selectedPeriod.segment, selectedPeriod.type,
+      [{
+        participantId: selectedParticipant.id,
+        meters: [
+          {
+            meterId: selectedMeter.meteringPoint,
+            meterDir: selectedMeter.direction,
+            from: selectedMeter.participantState
+              ? new Date(selectedMeter.participantState.activeSince).getTime()
+              : new Date().getTime(),
+            until: selectedMeter.participantState
+              ? new Date(selectedMeter.participantState.inactiveSince).getTime()
+              : new Date().getTime(),
+          } as MeterReport]
+      } as ParticipantReport])
+      .then(res => {
+        if (res.participantReports.length !== 1) {
+          throw new Error("Keine Daten gefunden")
+        }
+        return res.participantReports[0]
+      })
+      .then(rep => transformMeterReportToEnergySeries(rep.meters[0]))
+      .then(s => ({series: s, period: selectedPeriod} as MeterEnergySeries))
   }
 
 
@@ -86,34 +121,45 @@ const MeterChartComponent: FC<MeterChartComponentProps> = ({tenant, report, acti
       </div>
       <div style={{height: "200px", width: "100%"}}>
         <ResponsiveContainer width="90%" height={200}>
-          <BarChart
-            width={500}
-            height={300}
-            data={activeEnergySeries.series.map((e, i) => {
-              return {
+          {activeEnergySeries.period.type === 'D' ? (
+            <LineChart
+              data={activeEnergySeries.series.map((e) => ({
                 name: calcXAxisName(e.segmentIdx, activeEnergySeries.period),
                 distributed: e.allocated,
                 consumed: e.consumed
-              }
-            })}
-            margin={{
-              top: 5,
-              right: 30,
-              left: 20,
-              bottom: 5,
-            }}
-            barCategoryGap={0}
-            barGap={1}
-          >
-            <CartesianGrid strokeDasharray="3 3"/>
-            <XAxis dataKey="name"/>
-            <YAxis fontSize={10} unit={" kWh"}/>
-            <Tooltip formatter={(value) => Number(value).toFixed(3) + " kWh"}/>
-            <Legend/>
-            <Bar name="EEG" dataKey="distributed" fill="#82ca9d"/>
-            <Bar name="EVU" dataKey="consumed" fill="#8884d8"/>
-          </BarChart>
-
+              }))}
+              margin={{top: 5, right: 30, left: 20, bottom: 5}}
+            >
+              <CartesianGrid strokeDasharray="3 3"/>
+              <XAxis dataKey="name" interval={6} fontSize={10}/>
+              <YAxis fontSize={10} unit={" kWh"}/>
+              <Tooltip formatter={(value) => Number(value).toFixed(3) + " kWh"}/>
+              <Legend/>
+              <Line name="EEG" type="monotone" dataKey="distributed" stroke="#82ca9d" dot={false} strokeWidth={2}/>
+              <Line name="EVU" type="monotone" dataKey="consumed" stroke="#8884d8" dot={false} strokeWidth={2}/>
+            </LineChart>
+          ) : (
+            <BarChart
+              width={500}
+              height={300}
+              data={activeEnergySeries.series.map((e) => ({
+                name: calcXAxisName(e.segmentIdx, activeEnergySeries.period),
+                distributed: e.allocated,
+                consumed: e.consumed
+              }))}
+              margin={{top: 5, right: 30, left: 20, bottom: 5}}
+              barCategoryGap={0}
+              barGap={1}
+            >
+              <CartesianGrid strokeDasharray="3 3"/>
+              <XAxis dataKey="name"/>
+              <YAxis fontSize={10} unit={" kWh"}/>
+              <Tooltip formatter={(value) => Number(value).toFixed(3) + " kWh"}/>
+              <Legend/>
+              <Bar name="EEG" dataKey="distributed" fill="#82ca9d"/>
+              <Bar name="EVU" dataKey="consumed" fill="#8884d8"/>
+            </BarChart>
+          )}
         </ResponsiveContainer>
       </div>
     </div>

--- a/src/components/participantPane/MeterChartNavbar.component.tsx
+++ b/src/components/participantPane/MeterChartNavbar.component.tsx
@@ -1,6 +1,6 @@
 import React, {FC, useCallback, useEffect, useState} from "react";
 import {IonButton, IonButtons} from "@ionic/react";
-import {createNewPeriod, dateToDayOfYear, dayOfYearToDate} from "../../util/Helper.util";
+import {createNewPeriod, dateToDayOfYear, dayOfYearToDate, toLocalISODate} from "../../util/Helper.util";
 import {
   EnergySeries,
   SelectedPeriod
@@ -60,7 +60,7 @@ const MeterChartNavbarComponent: FC<MeterChartNavbarComponentProps> = ({selected
   }
 
   const currentDateValue = (selectedPeriod && selectedPeriod.type === 'D')
-    ? dayOfYearToDate(selectedPeriod.year, selectedPeriod.segment).toISOString().substring(0, 10)
+    ? toLocalISODate(dayOfYearToDate(selectedPeriod.year, selectedPeriod.segment))
     : ''
 
   return (

--- a/src/components/participantPane/MeterChartNavbar.component.tsx
+++ b/src/components/participantPane/MeterChartNavbar.component.tsx
@@ -1,6 +1,6 @@
 import React, {FC, useCallback, useEffect, useState} from "react";
 import {IonButton, IonButtons} from "@ionic/react";
-import {createNewPeriod} from "../../util/Helper.util";
+import {createNewPeriod, dateToDayOfYear, dayOfYearToDate} from "../../util/Helper.util";
 import {
   EnergySeries,
   SelectedPeriod
@@ -52,11 +52,22 @@ const MeterChartNavbarComponent: FC<MeterChartNavbarComponentProps> = ({selected
     }
   }, [selectedPeriod])
 
+  const onDateChange = (isoDate: string) => {
+    if (!isoDate || !selectedPeriod) return
+    const d = new Date(isoDate)
+    if (isNaN(d.getTime())) return
+    onChangePeriod({type: 'D', year: d.getFullYear(), segment: dateToDayOfYear(d)})
+  }
+
+  const currentDateValue = (selectedPeriod && selectedPeriod.type === 'D')
+    ? dayOfYearToDate(selectedPeriod.year, selectedPeriod.segment).toISOString().substring(0, 10)
+    : ''
+
   return (
     <div style={{display: "flex", alignItems: "center", justifyContent: "space-around"}}>
       <div>
         <IonButtons>
-          {(["Y", "YH", "YQ", "YM"] as ('YH' | "YQ" | 'YM' | 'Y')[]).map((p, i) => (
+          {(["Y", "YH", "YQ", "YM", "D"] as ('YH' | "YQ" | 'YM' | 'Y' | 'D')[]).map((p, i) => (
             <IonButton
               key={i}
               onClick={() => onChangePeriod(createNewPeriod(selectedPeriod, p, lastSegmentIdx, periods))}
@@ -72,7 +83,26 @@ const MeterChartNavbarComponent: FC<MeterChartNavbarComponentProps> = ({selected
         </IonButtons>
       </div>
       <div style={{width: "30%"}}>
-        <PeriodSelectorElement periods={periods} activePeriod={selectedPeriod} onUpdatePeriod={onChangePeriod} />
+        {selectedPeriod?.type === 'D' ? (
+          <input
+            type="date"
+            value={currentDateValue}
+            onChange={(e) => onDateChange(e.target.value)}
+            style={{
+              width: "140px",
+              fontSize: "inherit",
+              border: "none",
+              background: "transparent",
+              color: "inherit",
+              fontFamily: "var(--ion-font-family, inherit)",
+              padding: "4px 0",
+              textAlign: "left",
+              outline: "none"
+            }}
+          />
+        ) : (
+          <PeriodSelectorElement periods={periods} activePeriod={selectedPeriod} onUpdatePeriod={onChangePeriod} />
+        )}
       </div>
     </div>
   )

--- a/src/models/energy.model.ts
+++ b/src/models/energy.model.ts
@@ -88,7 +88,22 @@ export interface ProducerReport extends BaseReport {
   produced: number
 }
 
-export type ReportType = 'YH' | "YQ" | 'YM' | 'Y'
+export type ReportType = 'YH' | "YQ" | 'YM' | 'Y' | 'D'
+
+export interface RawData {
+  ts: number
+  value: number[]
+  qov?: number[]
+}
+
+export interface RawDataResult {
+  data: RawData[]
+  direction: "GENERATION" | "CONSUMPTION"
+}
+
+export interface RawDataResponse {
+  [meterId: string]: RawDataResult
+}
 
 export type EnergyPeriodType = {
   begin: string;

--- a/src/service/energy.service.ts
+++ b/src/service/energy.service.ts
@@ -4,6 +4,7 @@ import {
   EegEnergyReport,
   EnergyReportResponse,
   ParticipantReport,
+  RawDataResponse,
   RecordV2, ReportNamedData,
   SelectedPeriod,
   SummaryReportData
@@ -129,6 +130,21 @@ export class EnergyService extends BaseService {
       },
       body: JSON.stringify({type: type, year: year, segment: segment})
     }).then(this.handleErrors).then(res => res.json()).then(res => res[0]);
+  }
+
+  // Raw 15-min interval data for the day view. Note: our energystore expects the
+  // metering points in the request body ("meters"), not as ?cp= query params.
+  async fetchRawV2(tenant: ActiveTenant, start: number, end: number, meterIds: string[]): Promise<RawDataResponse> {
+    const token = await this.lookupToken()
+    return await fetch(`${ENERGY_API_SERVER}/eeg/v2/${tenant.ecId}/raw`, {
+      method: 'POST',
+      headers: {
+        ...this.getSecureHeadersX(token, tenant.rcNr),
+        'Accept': 'application/json',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({meters: meterIds, start, end})
+    }).then(this.handleErrors).then(res => res.json());
   }
 
   async createReport(tenant: ActiveTenant, payload: ExcelReportRequest) {

--- a/src/util/Helper.util.ts
+++ b/src/util/Helper.util.ts
@@ -81,7 +81,24 @@ export const periodDisplayString = (period: SelectedPeriod) => {
     case 'YQ': return `${MONTHNAME[(period.segment*3)-2].substring(0, 3)}-${MONTHNAME[period.segment*3].substring(0, 3)} ${period.year}`
     case 'YM': return `${MONTHNAME[period.segment]} ${period.year}`
     case 'Y' : return `${MONTHNAME[1].substring(0, 3)}-${MONTHNAME[12].substring(0, 3)} ${period.year}`
+    case 'D' : {
+      const d = dayOfYearToDate(period.year, period.segment)
+      return d.toISOString().substring(0, 10)
+    }
   }
+}
+
+// Day-of-year (1..366) → Date at 00:00 local time
+export const dayOfYearToDate = (year: number, dayOfYear: number) => {
+  const d = new Date(year, 0, 1, 0, 0, 0, 0)
+  d.setDate(d.getDate() + (dayOfYear - 1))
+  return d
+}
+
+export const dateToDayOfYear = (d: Date) => {
+  const start = new Date(d.getFullYear(), 0, 1, 0, 0, 0, 0)
+  const diff = d.getTime() - start.getTime()
+  return Math.floor(diff / (24 * 60 * 60 * 1000)) + 1
 }
 
 export const calcXAxisName = (i: number, period: SelectedPeriod) => {
@@ -108,6 +125,12 @@ export const calcXAxisName = (i: number, period: SelectedPeriod) => {
       return `${i+1}.${period.segment}`
     case 'Y' :
       return i >= 0 && i < 12 ? `${MONTHNAME[i+1].substring(0, 3)}` : `${i}`
+    case 'D' : {
+      // 96 × 15-min slots: i is 0..95 → "HH:MM"; recharts XAxis interval controls density
+      const hour = Math.floor(i / 4)
+      const minute = (i % 4) * 15
+      return `${hour.toString().padStart(2, '0')}:${minute.toString().padStart(2, '0')}`
+    }
   }
 }
 
@@ -128,6 +151,11 @@ export const getPreviousPeriod = (period: SelectedPeriod) => {
 export const createNewPeriod = (period: SelectedPeriod | undefined, target: ReportType, currentSegmentIdx: number, cpPeriod?: CpPeriodType) => {
   if (period !== undefined) {
     switch (target) {
+      case 'D': {
+        const today = new Date()
+        const sameYear = today.getFullYear() === period.year
+        return {type: target, year: period.year, segment: sameYear ? dateToDayOfYear(today) : 1}
+      }
       case 'Y':
         return {type: target, segment: 0, year: period.year}
       case 'YM':
@@ -139,6 +167,8 @@ export const createNewPeriod = (period: SelectedPeriod | undefined, target: Repo
             return {type: target, segment: splitedPeriod ? splitedPeriod[3] : period.segment === 2 ? 6 : 1, year: splitedPeriod ? splitedPeriod[2] : period.year}
           case 'YQ':
             return {type: target, segment: splitedPeriod ? splitedPeriod[3] : period.segment === 2 ? 3 : period.segment === 3 ? 6 : period.segment === 4 ? 9 : 1, year: splitedPeriod ? splitedPeriod[2] : period.year}
+          case 'D':
+            return {type: target, segment: dayOfYearToDate(period.year, period.segment).getMonth() + 1, year: period.year}
           default:
             return period
         }
@@ -150,6 +180,8 @@ export const createNewPeriod = (period: SelectedPeriod | undefined, target: Repo
             return {type: target, segment: period.segment === 2 ? 3 : 1, year: period.year}
           case 'YM':
             return {type: target, segment: Math.ceil(period.segment / 3), year: period.year}
+          case 'D':
+            return {type: target, segment: Math.ceil((dayOfYearToDate(period.year, period.segment).getMonth() + 1) / 3), year: period.year}
           default:
             return period
         }
@@ -161,6 +193,8 @@ export const createNewPeriod = (period: SelectedPeriod | undefined, target: Repo
             return {type: target, segment: Math.max(1, Math.ceil(period.segment / 2)), year: period.year}
           case 'YM':
             return {type: target, segment: Math.max(1, Math.ceil(period.segment / 6)), year: period.year}
+          case 'D':
+            return {type: target, segment: Math.max(1, Math.ceil((dayOfYearToDate(period.year, period.segment).getMonth() + 1) / 6)), year: period.year}
           default:
             return period
         }

--- a/src/util/Helper.util.ts
+++ b/src/util/Helper.util.ts
@@ -83,7 +83,7 @@ export const periodDisplayString = (period: SelectedPeriod) => {
     case 'Y' : return `${MONTHNAME[1].substring(0, 3)}-${MONTHNAME[12].substring(0, 3)} ${period.year}`
     case 'D' : {
       const d = dayOfYearToDate(period.year, period.segment)
-      return d.toISOString().substring(0, 10)
+      return toLocalISODate(d)
     }
   }
 }
@@ -99,6 +99,14 @@ export const dateToDayOfYear = (d: Date) => {
   const start = new Date(d.getFullYear(), 0, 1, 0, 0, 0, 0)
   const diff = d.getTime() - start.getTime()
   return Math.floor(diff / (24 * 60 * 60 * 1000)) + 1
+}
+
+// Format a Date as YYYY-MM-DD from its LOCAL components. Avoids the UTC shift of
+// toISOString(), which renders the previous day in positive-UTC zones (e.g. a
+// local 30.06 00:00 in Europe/Vienna becomes "2026-06-29").
+export const toLocalISODate = (d: Date) => {
+  const pad = (n: number) => n.toString().padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
 }
 
 export const calcXAxisName = (i: number, period: SelectedPeriod) => {

--- a/src/util/PeriodHelper.functions.ts
+++ b/src/util/PeriodHelper.functions.ts
@@ -2,8 +2,9 @@ import {ReportType, SelectedPeriod} from "../models/energy.model";
 import {getPeriodSegment} from "./Helper.util";
 import moment from "moment";
 
-export const generatePeriodOptions = (period: 'YH' | "YQ" | 'YM' | 'Y', endMonth: number, endYear: number, beginMonth: number, beginYear: number) => {
+export const generatePeriodOptions = (period: ReportType, endMonth: number, endYear: number, beginMonth: number, beginYear: number) => {
   const options: SelectedPeriod[] = [];
+  if (period === 'D') return options
   for (let y = beginYear; y <= endYear; y++) {
     const em = y === endYear ? endMonth : 12
     const bm = y === beginYear ? beginMonth : 1
@@ -21,7 +22,7 @@ export const generatePeriodOptions = (period: 'YH' | "YQ" | 'YM' | 'Y', endMonth
   return options.sort((a, b) => (a.year+(a.segment*0.01)) > (b.segment*0.01+b.year) ? -1 : 1);
 }
 
-export const getSegmentFromDate = (periodType: ReportType, year: number, date: moment.Moment) => {
+export const getSegmentFromDate = (periodType: ReportType, year: number, date: moment.Moment): number => {
   if (date.year() === year) {
     switch (periodType) {
       case 'Y':
@@ -32,6 +33,8 @@ export const getSegmentFromDate = (periodType: ReportType, year: number, date: m
         return date.quarter()
       case 'YM':
         return date.month() + 1
+      case 'D':
+        return date.dayOfYear()
     }
   } else {
     switch (periodType) {
@@ -43,12 +46,15 @@ export const getSegmentFromDate = (periodType: ReportType, year: number, date: m
         return 4
       case 'YM':
         return 12
+      case 'D':
+        return 1
     }
   }
 }
 
 export const transformPeriodFromSegment = (targetType: ReportType, period: SelectedPeriod, date: moment.Moment): SelectedPeriod => {
   switch (targetType) {
+    case 'D': return {type: 'D', segment: date.dayOfYear(), year: period.year} as SelectedPeriod
     case 'Y': return {type: targetType, segment: 0, year: period.year} as SelectedPeriod
     case 'YH':
       switch (period.type) {
@@ -60,6 +66,8 @@ export const transformPeriodFromSegment = (targetType: ReportType, period: Selec
           return {type: targetType, segment: Math.min(getSegmentFromDate(targetType, period.year, date), period.segment > 2 ? 2 : 1), year: period.year} as SelectedPeriod
         case 'YM':
           return {type: targetType, segment: Math.min(getSegmentFromDate(targetType, period.year, date), period.segment > 6 ? 2 : 1), year: period.year} as SelectedPeriod
+        case 'D':
+          return {type: targetType, segment: getSegmentFromDate(targetType, period.year, date), year: period.year} as SelectedPeriod
       }
     case 'YQ':
       switch (period.type) {
@@ -71,6 +79,8 @@ export const transformPeriodFromSegment = (targetType: ReportType, period: Selec
           return period
         case 'YM':
           return {type: targetType, segment: Math.min(getSegmentFromDate(targetType, period.year, date), period.segment > 9 ? 4 : period.segment > 6 ? 3 : period.segment > 3 ? 2 : 1), year: period.year} as SelectedPeriod
+        case 'D':
+          return {type: targetType, segment: getSegmentFromDate(targetType, period.year, date), year: period.year} as SelectedPeriod
       }
     case 'YM':
       switch (period.type) {
@@ -82,6 +92,8 @@ export const transformPeriodFromSegment = (targetType: ReportType, period: Selec
           return {type: targetType, segment: Math.min(getSegmentFromDate(targetType, period.year, date), period.segment * 3), year: period.year} as SelectedPeriod
         case 'YM':
           return period
+        case 'D':
+          return {type: targetType, segment: getSegmentFromDate(targetType, period.year, date), year: period.year} as SelectedPeriod
       }
   }
 }


### PR DESCRIPTION
## Was

Fügt dem Energie-Chart eines Zählpunkts eine **Tagesansicht** (`D`) hinzu: die 96 × 15-Minuten-Werte des Tages als **Liniendiagramm** (EEG vs. EVU), mit Tag-für-Tag-Navigation (Datums-Picker). Zusätzlich startet der Perioden-Wechsel jetzt auf dem **aktuellen Datum** statt am EEG-Perioden-Ende (das oft noch keine Daten hat).

## Herkunft / Lizenz

Portiert aus einem AGPL-3.0-Schwester-Deployment (beide Repos AGPL-3.0; Lizenzvermerke erhalten, keine Cross-Org-Verweise).

## Backend

Nutzt den bereits vorhandenen energystore-Endpoint **`POST /eeg/v2/{ec}/raw`** (Prod: `energystore:v1.0.0`). Response-Form (`map[meter] → {data:[{ts,value[]}], direction}`) deckt sich 1:1 mit der Transform-Logik. **Angepasst ggü. der Quelle:** Zählpunkte werden im **Request-Body** (`meters:[]`) gesendet, nicht als `?cp=`-Query — passend zu unserem Handler `fetchRawEnergyV2` (`model.RawDataRequest`).

## Dateien (7)

- `models/energy.model.ts` — `RawData`/`RawDataResult`/`RawDataResponse`, `ReportType` um `'D'`
- `service/energy.service.ts` — `fetchRawV2` (Meter im Body)
- `util/Helper.util.ts` — `dayOfYearToDate`/`dateToDayOfYear` + `'D'` in periodDisplayString/calcXAxisName/createNewPeriod
- `util/PeriodHelper.functions.ts` — `'D'` in generatePeriodOptions/getSegmentFromDate/transformPeriodFromSegment
- `components/participantPane/MeterChart.component.tsx` — LineChart-Zweig + `fetchDaySeries` + `transformRawToEnergySeries`
- `components/participantPane/MeterChartNavbar.component.tsx` — `D`-Button + Tages-Datums-Navigation
- `components/dashboard/ChartProperties.component.tsx` — `'D'`-Case + Default-auf-heute

## Verifikation

`vite build` grün (CI-Gate des Repos). `tsc --noEmit` zeigt **keine** Fehler in den geänderten Dateien (die bekannten Repo-weiten tsc-Drifts sind vorbestehend, daher baut CI mit vite).

## Noch zu prüfen / Hinweise

- **`value[]`-Semantik gegenchecken:** Annahme aus der Quelle — CONSUMPTION `value[0]=Consumed`, `value[2]=Distributed`; Erzeugung `value[0]=Produced`, `value[1]=Allocation`. In der Dev-Zone visuell verifizieren.
- **Nicht enthalten (bewusst, out of scope):** der in der Quelle mitgebündelte GraphQL-Fix `eeg()` → `eeg` (`service/graphql-query.ts`). Das ist ein separater Latent-Bug (ungültiges GraphQL in der genutzten `EegInfo`-Query) — eigener PR.
- Kein Release/Deploy: erst nach Support-Verifikation in der Dev-Zone.