### PR TITLE
feat(meter-chart): lokalisierter IonDatetime-Picker für die Tagesansicht

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ this changelog highlights the changes relevant for overview and operations.
 ### Changed
 - Chart period switch now defaults to the current date's segment instead of the
   EEG period end (which often has no data yet).
+- Day view date navigation uses Ionic's localized `IonDatetime` picker
+  (`de-DE`, `DD.MM.YYYY`) instead of a raw native `<input type="date">`.
 
 ## [1.0.3] – 2026-06-29
 

--- a/src/components/participantPane/MeterChartNavbar.component.tsx
+++ b/src/components/participantPane/MeterChartNavbar.component.tsx
@@ -1,5 +1,5 @@
 import React, {FC, useCallback, useEffect, useState} from "react";
-import {IonButton, IonButtons} from "@ionic/react";
+import {IonButton, IonButtons, IonDatetime, IonDatetimeButton, IonModal} from "@ionic/react";
 import {createNewPeriod, dateToDayOfYear, dayOfYearToDate, toLocalISODate} from "../../util/Helper.util";
 import {
   EnergySeries,
@@ -84,22 +84,18 @@ const MeterChartNavbarComponent: FC<MeterChartNavbarComponentProps> = ({selected
       </div>
       <div style={{width: "30%"}}>
         {selectedPeriod?.type === 'D' ? (
-          <input
-            type="date"
-            value={currentDateValue}
-            onChange={(e) => onDateChange(e.target.value)}
-            style={{
-              width: "140px",
-              fontSize: "inherit",
-              border: "none",
-              background: "transparent",
-              color: "inherit",
-              fontFamily: "var(--ion-font-family, inherit)",
-              padding: "4px 0",
-              textAlign: "left",
-              outline: "none"
-            }}
-          />
+          <>
+            <IonDatetimeButton datetime="meter-day-datetime"/>
+            <IonModal keepContentsMounted={true}>
+              <IonDatetime
+                id="meter-day-datetime"
+                presentation="date"
+                locale="de-DE"
+                value={currentDateValue}
+                onIonChange={(e) => { if (typeof e.detail.value === 'string') onDateChange(e.detail.value) }}
+              />
+            </IonModal>
+          </>
         ) : (
           <PeriodSelectorElement periods={periods} activePeriod={selectedPeriod} onUpdatePeriod={onChangePeriod} />
         )}


### PR DESCRIPTION
**Folge-PR zu #63 — gestapelt auf `feat/zaehlpunkt-tagesansicht`** (Base ist die #63-Branch, nicht master; nach Merge von #63 retargete ich auf master).

## Was

Ersetzt in der Tagesansicht das rohe native `<input type="date">` durch Ionics **`IonDatetime`** (`IonDatetimeButton` + `IonModal`, `locale="de-DE"`).

## Warum

- Ein natives `type="date"` rendert die Segment-Reihenfolge in der **Browser-Locale** (en-US → MM/DD) → für AT-Nutzer „bei Monat komisch", per HTML nicht änderbar. (Gleiche Klasse Problem wie der gerade gefixte Admin-Datums-Bug.)
- Es ist nicht im Ionic-Design-System gestylt. `IonDatetime` ist deterministisch (`DD.MM.YYYY`) und konsistent.

## Korrektheit

Round-trip bleibt lokal/zeitzonensicher: `value` kommt aus `toLocalISODate(...)` (lokal, kein UTC-Shift — der Off-by-One aus #63 ist dort bereits behoben), `onIonChange` → `onDateChange` → `dateToDayOfYear` (lokal).

## Verifikation

`vite build` grün; `tsc --noEmit` ohne Fehler in der geänderten Datei.

Nur eine Datei: `components/participantPane/MeterChartNavbar.component.tsx` (+ CHANGELOG).