### PR TITLE
ci: Snyk Code (SAST) Workflow

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,0 +1,27 @@
+name: Snyk Code (SAST)
+
+on:
+  push:
+    branches: ["master"]
+  schedule:
+    - cron: "23 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  snyk-code:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: "20"
+      - name: Install Snyk CLI
+        run: npm install -g snyk
+      - name: Snyk Code test (SAST)
+        continue-on-error: true
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        run: snyk code test --severity-threshold=high


### PR DESCRIPTION
Fügt einen **Snyk Code (SAST)** Workflow hinzu (Teil der org-weiten Snyk-Automatisierung, 2026-06-30).

- Trigger: `push` auf den Default-Branch, wöchentlicher Schedule, `workflow_dispatch` — **keine** `pull_request`-Trigger (kein SNYK_TOKEN-Leak über Fork-PRs).
- `continue-on-error`: report-only, blockt die bestehende Build-Pipeline nicht.
- Actions auf Commit-SHA gepinnt (security.md).

**Voraussetzung:** Org-Secret `SNYK_TOKEN` muss gesetzt sein (vom Operator, **generischer VFEEG-Snyk-Token** aus dem zentralen Kennwort-Store — NICHT der persönliche CLI-Token). Bis dahin ist der Workflow inert.

Hinweis: SCA (Open-Source-Dependencies) ist bereits über Dependabot abgedeckt; dieser Workflow ergänzt SAST. SCA-via-Snyk kann pro Repo später nachgerüstet werden.