### PR TITLE
ci: Snyk SARIF -> GitHub Code Scanning

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  security-events: write
 
 jobs:
   snyk-code:
@@ -24,4 +25,9 @@ jobs:
         continue-on-error: true
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        run: snyk code test --severity-threshold=high
+        run: snyk code test --severity-threshold=high --sarif-file-output=snyk.sarif
+      - name: Upload SARIF to GitHub Code Scanning
+        if: ${{ always() && hashFiles('snyk.sarif') != '' }}
+        uses: github/codeql-action/upload-sarif@35632bdbd38dba649ce80e15482f7a399a32d400 # v3.27.9
+        with:
+          sarif_file: snyk.sarif


### PR DESCRIPTION
Erweitert den Snyk-Code-Workflow um SARIF-Upload -> Findings erscheinen als Code-Scanning-Alerts im Security-Tab (statt nur im Job-Log). Guard: Upload nur wenn snyk.sarif erzeugt wurde. permissions: security-events: write. Action SHA-gepinnt (v3.27.9).