### PR TITLE
feat(meter-chart): lokalisierter IonDatetime-Picker für die Tagesansicht

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ this changelog highlights the changes relevant for overview and operations.
 ### Changed
 - Chart period switch now defaults to the current date's segment instead of the
   EEG period end (which often has no data yet).
+- Day view date navigation uses Ionic's localized `IonDatetime` picker
+  (`de-DE`, `DD.MM.YYYY`) instead of a raw native `<input type="date">`.
 
 ## [1.0.3] – 2026-06-29
 

--- a/src/components/participantPane/MeterChartNavbar.component.tsx
+++ b/src/components/participantPane/MeterChartNavbar.component.tsx
@@ -1,5 +1,5 @@
 import React, {FC, useCallback, useEffect, useState} from "react";
-import {IonButton, IonButtons} from "@ionic/react";
+import {IonButton, IonButtons, IonDatetime, IonDatetimeButton, IonModal} from "@ionic/react";
 import {createNewPeriod, dateToDayOfYear, dayOfYearToDate, toLocalISODate} from "../../util/Helper.util";
 import {
   EnergySeries,
@@ -84,22 +84,18 @@ const MeterChartNavbarComponent: FC<MeterChartNavbarComponentProps> = ({selected
       </div>
       <div style={{width: "30%"}}>
         {selectedPeriod?.type === 'D' ? (
-          <input
-            type="date"
-            value={currentDateValue}
-            onChange={(e) => onDateChange(e.target.value)}
-            style={{
-              width: "140px",
-              fontSize: "inherit",
-              border: "none",
-              background: "transparent",
-              color: "inherit",
-              fontFamily: "var(--ion-font-family, inherit)",
-              padding: "4px 0",
-              textAlign: "left",
-              outline: "none"
-            }}
-          />
+          <>
+            <IonDatetimeButton datetime="meter-day-datetime"/>
+            <IonModal keepContentsMounted={true}>
+              <IonDatetime
+                id="meter-day-datetime"
+                presentation="date"
+                locale="de-DE"
+                value={currentDateValue}
+                onIonChange={(e) => { if (typeof e.detail.value === 'string') onDateChange(e.detail.value) }}
+              />
+            </IonModal>
+          </>
         ) : (
           <PeriodSelectorElement periods={periods} activePeriod={selectedPeriod} onUpdatePeriod={onChangePeriod} />
         )}


### PR DESCRIPTION
Ersetzt in der Tagesansicht das native `<input type="date">` durch Ionics **`IonDatetime`** (`IonDatetimeButton` + `IonModal`, `locale="de-DE"`, DD.MM.YYYY). Deterministisch + Ionic-konform; behebt die browser-locale-abhängige Segment-Reihenfolge.

Neuauflage des Folge-PRs zu #63 (das ursprüngliche #64 wurde beim Squash-Merge von #63 auto-geschlossen). Nur `MeterChartNavbar.component.tsx` (+ CHANGELOG). Round-trip bleibt lokal/zeitzonensicher (`toLocalISODate` aus #63). `vite build` grün.