### PR TITLE
test(meter-address-form): bind status select to the right form field

### DIFF
--- a/src/__test__/components/core/forms/MeterAddressForm/MeterAddressForm.test.tsx
+++ b/src/__test__/components/core/forms/MeterAddressForm/MeterAddressForm.test.tsx
@@ -54,6 +54,7 @@ const renderElement = (online: boolean, admin: boolean, owner: boolean, status: 
     <EegContext.Provider value={ctxValue(admin, owner, false)} >
       <MeterAddressFormElement participant={defaultParticipant} isOnline={online} isEditable={isEditable} showActivationMode={false}/>
     </EegContext.Provider>, { defaultValues: {
+        status: status,
         processState: status,
         participantId: "",
         meteringPoint: "",


### PR DESCRIPTION
## Was

Folge-Fix zu #68 (Suite-Reaktivierung). Behebt **2 der 4** beim Revival sichtbar gewordenen Testfehler — **rein test-seitig**, kein Komponenten-/App-Code.

`MeterAddressForm` rendert den Status-`<ion-select>` via `SelectForm name="status"`. Der Test initialisierte das Formular aber nur mit `processState` → das `ion-select` hatte keinen Wert → `toHaveValue("ACTIVE"/"NEW")` schlug fehl. Fix: `status` in den Test-`defaultValues` setzen (1 Zeile).

## Verifikation
- `MeterAddressForm.test.tsx`: **4/4 grün** (vorher 2 rot).
- Gesamt-Suite: **10/12 grün** (vorher komplett tot, dann 8/12).

## Bewusst NICHT hier (Domänen-Entscheidung, kein Auto-Fix)
Die verbleibenden 2 Fehler hängen an **auskommentierten App-Filtern** — ein „grüner" Test würde evtl. fehlerhaftes Verhalten zementieren:
- **#69** `filterActiveParticipantAndMeter` (inaktive ZP bleiben im Zeitraum)
- **#70** `buildAllocationMapFromSelected` (0-Allokationen + Store-Abhängigkeit + Output-Drift)

Beide könnten echte Bugs sein und brauchen eine fachliche Klärung, bevor Code/Test geändert wird.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
