### PR TITLE
feat(meter-chart): limit day picker to the billing-period date range

### DIFF
--- a/src/components/participantPane/MeterChartNavbar.component.tsx
+++ b/src/components/participantPane/MeterChartNavbar.component.tsx
@@ -1,6 +1,6 @@
 import React, {FC, useCallback, useEffect, useState} from "react";
 import {IonButton, IonButtons, IonDatetime, IonDatetimeButton, IonModal} from "@ionic/react";
-import {createNewPeriod, dateToDayOfYear, dayOfYearToDate, toLocalISODate} from "../../util/Helper.util";
+import {createNewPeriod, dateToDayOfYear, dayOfYearToDate, splitDate, toLocalISODate} from "../../util/Helper.util";
 import {
   EnergySeries,
   SelectedPeriod
@@ -63,6 +63,17 @@ const MeterChartNavbarComponent: FC<MeterChartNavbarComponentProps> = ({selected
     ? toLocalISODate(dayOfYearToDate(selectedPeriod.year, selectedPeriod.segment))
     : ''
 
+  // Restrict the day picker to the range that actually has billing-period data
+  // (begin..end from the meta periods) — mirrors the YM period selector, which
+  // only lists months within that range. No range available -> leave unconstrained.
+  const periodToISODate = (date: string): string | undefined => {
+    const [day, month, year] = splitDate(date)
+    return (year && month && day) ? toLocalISODate(new Date(year, month - 1, day)) : undefined
+  }
+  const minDate = periodToISODate(periods.begin)
+  const maxDate = periodToISODate(periods.end)
+  const hasDayRange = !!minDate && !!maxDate
+
   return (
     <div style={{display: "flex", alignItems: "center", justifyContent: "space-around"}}>
       <div>
@@ -92,6 +103,8 @@ const MeterChartNavbarComponent: FC<MeterChartNavbarComponentProps> = ({selected
                 presentation="date"
                 locale="de-DE"
                 value={currentDateValue}
+                min={hasDayRange ? minDate : undefined}
+                max={hasDayRange ? maxDate : undefined}
                 onIonChange={(e) => { if (typeof e.detail.value === 'string') onDateChange(e.detail.value) }}
               />
             </IonModal>


### PR DESCRIPTION
## Was
Im Meter-Chart war der **Tagesansicht-Datepicker (D)** ein freier Kalender — **alle Tage** wählbar, auch ohne Daten. Die Monats-/Jahres-Selektoren (Y/YH/YQ/YM) begrenzen die Auswahl bereits auf den Perioden-Bereich.

## Änderung
`MeterChartNavbar.component.tsx`: am `IonDatetime` (Day-Picker) `min`/`max` aus `periods` (`periodsSelector` `{begin,end}`) gesetzt — derselbe Datensatz, der die YM-Liste speist. Spiegelt damit die Monatsansicht (range-basiert `begin..end`). Ohne verfügbaren Bereich bleibt der Picker unbeschränkt (Fallback = altes Verhalten).

`begin`/`end` (Format `DD.MM.YYYY`) werden via `splitDate` → ISO (`YYYY-MM-DD`) für IonDatetime konvertiert.

## QA
- `tsc`: keine neuen Typfehler (Change typecheckt sauber).
- Vitest: **10/12** grün; die 2 roten (`FilterHelper.util.test.ts` #69, `ParticipantPane.functions.test.tsx` #70) sind **vorbestehend** und betreffen andere Module → keine Regression.
- Reine UI-Änderung — kein Auth/Tenant/SQL/Endpoint/Secret, keine neuen Deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
