### PR TITLE
fix: derive next member number from max, not active count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@ this changelog highlights the changes relevant for overview and operations.
 - Metering point day view now defaults to **yesterday** instead of today, because
   today's 15-minute data is still incomplete when the view opens.
 
+### Fixed
+- Member registration: the suggested next member number was derived from the
+  count of *active* members (`activeParticipants.length + 1`), which recycled the
+  numbers of archived members and collided with the per-tenant unique index on
+  `base.participant` (customer report: the suggestion is often wrong). Derive it
+  instead from the highest numeric tail across *all* members (incl. archived),
+  preserving any prefix and zero-padding (`001→002`, `MG-001→MG-002`), and
+  re-sync the form field once the member list resolves unless the user already
+  edited it. Ported from an AGPL-3.0 sibling deployment.
+
 ## [1.0.4] – 2026-06-30
 
 ### Security

--- a/src/pages/ParticipantRegister.page.tsx
+++ b/src/pages/ParticipantRegister.page.tsx
@@ -1,4 +1,4 @@
-import React, {FC, useState} from "react";
+import React, {FC, useEffect, useMemo} from "react";
 import {
   IonButton,
   IonButtons,
@@ -15,7 +15,7 @@ import {
 import "./ParticipantRegister.page.scss"
 import ParticipantRegisterCommonPaneComponent from "../components/ParticipantRegisterCommonPane.component";
 import {
-  activeParticipantsSelector1,
+  allParticipantsSelector,
   createParticipant,
 } from "../store/participant";
 import {EegParticipant} from "../models/members.model";
@@ -34,17 +34,35 @@ const ParticipantRegisterPage: FC<RouteComponentProps> = ({history}) => {
   const dispatch = useAppDispatch();
 
   const {tenant} = useTenant()
-  const participants = useAppSelector(activeParticipantsSelector1);
-  const [defaultParticipantNumber, setDefaultParticipantNumber] = useState(participants.length.toString().padStart(3, '0'))
+  // Vorschlag der nächsten Mitglieds-Nr über ALLE Mitglieder (inkl. archivierte),
+  // nicht über die Anzahl der aktiven. `activeParticipantsSelector1.length + 1`
+  // recycelte Nummern archivierter Mitglieder und kollidierte mit dem
+  // Unique-Index auf base.participant (Kundenfeedback 2026-07-02: Nummern-
+  // vorschlag oft falsch).
+  const allParticipants = useAppSelector(allParticipantsSelector);
 
-  // useEffect(() => {
-  //   setDefaultParticipantNumber(participants.length.toString().padStart(3, '0'))
-  // }, [participants])
-
+  // Höchsten numerischen Endteil einer bestehenden Nummer nehmen, dessen Präfix
+  // und Zero-Padding-Breite erhalten, und Präfix + (max + 1) vorschlagen.
+  // Beispiele: ["001","002","004"] → "005"; ["MG-001"] → "MG-002";
+  // ["ABC123"] → "ABC124"; leer/nichts parsebar → "001".
+  const nextParticipantNumber = useMemo(() => {
+    let best: {prefix: string, num: number, padding: number} | null = null
+    for (const p of allParticipants) {
+      const match = (p.participantNumber || "").match(/^(.*?)(\d+)$/)
+      if (!match) continue
+      const num = parseInt(match[2], 10)
+      if (isNaN(num)) continue
+      if (!best || num > best.num) {
+        best = {prefix: match[1], num, padding: match[2].length}
+      }
+    }
+    if (!best) return "001"
+    return best.prefix + (best.num + 1).toString().padStart(best.padding, '0')
+  }, [allParticipants])
 
   const selectedParticipant: EegParticipant = {
     id: '',
-    participantNumber: (participants.length + 1).toString().padStart(3, '0'),
+    participantNumber: nextParticipantNumber,
     participantSince: new Date(),
     firstname: '',
     lastname: '',
@@ -64,8 +82,17 @@ const ParticipantRegisterPage: FC<RouteComponentProps> = ({history}) => {
     meters: []} as EegParticipant
 
   const formMethods = useForm<EegParticipant>({defaultValues: selectedParticipant, mode: "onBlur", reValidateMode: 'onChange'})
-  const {reset, handleSubmit} = formMethods
+  const {reset, handleSubmit, setValue, formState: {dirtyFields}} = formMethods
   // const {append} = useFieldArray<EegParticipant>({control, name: 'meters'})
+
+  // Async-Race: useForm({defaultValues}) erfasst die Nummer beim ersten Render,
+  // bevor die Mitgliederliste geladen ist. Sobald nextParticipantNumber steht,
+  // das Feld nachziehen — außer der Nutzer hat es bereits selbst editiert.
+  useEffect(() => {
+    if (!dirtyFields.participantNumber) {
+      setValue("participantNumber", nextParticipantNumber)
+    }
+  }, [nextParticipantNumber, dirtyFields.participantNumber, setValue])
 
   const onRegisterParticipant = (participant: EegParticipant) => {
     dispatch(createParticipant({tenant, participant}))


### PR DESCRIPTION
## Problem

Kundenfeedback: Der automatische Vorschlag der nächsten Mitglieds-Nr bei der Anlage eines neuen Mitglieds ist oft falsch.

Ursache in `ParticipantRegister.page.tsx`: die nächste Nummer wurde als **Anzahl der aktiven Mitglieder + 1** ermittelt (`activeParticipantsSelector1.length + 1`). Das zählt archivierte/inaktive Mitglieder nicht mit und ignoriert Lücken, Import-Nummern und Präfixe — die vorgeschlagene Nummer recycelt dann eine bereits vergebene und kollidiert mit dem tenant-weiten Unique-Index auf `base.participant`.

Zusätzlich erfasste `useForm({defaultValues})` den Vorschlag beim ersten Render, bevor die Mitgliederliste geladen war (der alte, auskommentierte `useEffect` hat diese Race nie behoben).

## Lösung

- Vorschlag aus dem **höchsten numerischen Endteil über ALLE Mitglieder** (inkl. archiviert, via bereits vorhandenem `allParticipantsSelector`), Präfix und Zero-Padding-Breite erhalten:
  - `["001","002","004"] → "005"`, `["MG-001"] → "MG-002"`, `["ABC123"] → "ABC124"`, leer → `"001"`.
- `useEffect`, der das Formularfeld nachzieht, sobald die Liste geladen ist — **außer** der Nutzer hat es selbst editiert (`dirtyFields`-Guard).

Chirurgisch: nur `ParticipantRegister.page.tsx` (kein Backend, kein neuer Selektor). Portiert aus einem AGPL-3.0-Schwester-Deployment.

## Test

- `tsc --noEmit`: 0 Fehler.
- Vitest unverändert (10/12; die 2 Fehlschläge sind die bekannten #69/#70 in `ParticipantPane.functions`/`FilterHelper.util` und importieren diese Datei nicht).
- Für `ParticipantRegister` existiert kein Unit-Test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
