### PR TITLE
feat: day view prev/next-day arrows + default to yesterday

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ this changelog highlights the changes relevant for overview and operations.
 
 ## [Unreleased]
 
+### Added
+- Metering point day view: previous/next-day arrows around the date, so you can
+  step through days without opening the calendar and see the chart update in
+  place. The arrows are clamped to (and disabled at the edges of) the same
+  billing-period range as the date picker; the calendar stays for larger jumps.
+
+### Changed
+- Metering point day view now defaults to **yesterday** instead of today, because
+  today's 15-minute data is still incomplete when the view opens.
+
 ## [1.0.4] – 2026-06-30
 
 ### Security

--- a/src/components/participantPane/MeterChartNavbar.component.tsx
+++ b/src/components/participantPane/MeterChartNavbar.component.tsx
@@ -1,5 +1,6 @@
 import React, {FC, useCallback, useEffect, useState} from "react";
-import {IonButton, IonButtons, IonDatetime, IonDatetimeButton, IonModal} from "@ionic/react";
+import {IonButton, IonButtons, IonDatetime, IonDatetimeButton, IonIcon, IonModal} from "@ionic/react";
+import {chevronBack, chevronForward} from "ionicons/icons";
 import {createNewPeriod, dateToDayOfYear, dayOfYearToDate, splitDate, toLocalISODate} from "../../util/Helper.util";
 import {
   EnergySeries,
@@ -74,6 +75,18 @@ const MeterChartNavbarComponent: FC<MeterChartNavbarComponentProps> = ({selected
   const maxDate = periodToISODate(periods.end)
   const hasDayRange = !!minDate && !!maxDate
 
+  // Step one day back/forward without opening the calendar. Clamp to the same
+  // range the picker is restricted to (ISO date strings compare lexicographically).
+  const stepDay = (delta: number) => {
+    if (!selectedPeriod || selectedPeriod.type !== 'D') return
+    const d = dayOfYearToDate(selectedPeriod.year, selectedPeriod.segment)
+    d.setDate(d.getDate() + delta)
+    if (hasDayRange && (toLocalISODate(d) < minDate! || toLocalISODate(d) > maxDate!)) return
+    onChangePeriod({type: 'D', year: d.getFullYear(), segment: dateToDayOfYear(d)})
+  }
+  const prevDisabled = hasDayRange && currentDateValue <= minDate!
+  const nextDisabled = hasDayRange && currentDateValue >= maxDate!
+
   return (
     <div style={{display: "flex", alignItems: "center", justifyContent: "space-around"}}>
       <div>
@@ -95,8 +108,14 @@ const MeterChartNavbarComponent: FC<MeterChartNavbarComponentProps> = ({selected
       </div>
       <div style={{width: "30%"}}>
         {selectedPeriod?.type === 'D' ? (
-          <>
+          <div style={{display: "flex", alignItems: "center", justifyContent: "center", gap: "4px"}}>
+            <IonButton fill="clear" size="small" onClick={() => stepDay(-1)} disabled={prevDisabled} aria-label="Vorheriger Tag">
+              <IonIcon slot="icon-only" icon={chevronBack}/>
+            </IonButton>
             <IonDatetimeButton datetime="meter-day-datetime"/>
+            <IonButton fill="clear" size="small" onClick={() => stepDay(1)} disabled={nextDisabled} aria-label="Nächster Tag">
+              <IonIcon slot="icon-only" icon={chevronForward}/>
+            </IonButton>
             <IonModal keepContentsMounted={true}>
               <IonDatetime
                 id="meter-day-datetime"
@@ -108,7 +127,7 @@ const MeterChartNavbarComponent: FC<MeterChartNavbarComponentProps> = ({selected
                 onIonChange={(e) => { if (typeof e.detail.value === 'string') onDateChange(e.detail.value) }}
               />
             </IonModal>
-          </>
+          </div>
         ) : (
           <PeriodSelectorElement periods={periods} activePeriod={selectedPeriod} onUpdatePeriod={onChangePeriod} />
         )}

--- a/src/util/Helper.util.ts
+++ b/src/util/Helper.util.ts
@@ -160,9 +160,12 @@ export const createNewPeriod = (period: SelectedPeriod | undefined, target: Repo
   if (period !== undefined) {
     switch (target) {
       case 'D': {
-        const today = new Date()
-        const sameYear = today.getFullYear() === period.year
-        return {type: target, year: period.year, segment: sameYear ? dateToDayOfYear(today) : 1}
+        // Default to yesterday, not today: today's 15-minute data is still
+        // incomplete, so the day view opens on the last fully-recorded day.
+        const yesterday = new Date()
+        yesterday.setDate(yesterday.getDate() - 1)
+        const sameYear = yesterday.getFullYear() === period.year
+        return {type: target, year: period.year, segment: sameYear ? dateToDayOfYear(yesterday) : 1}
       }
       case 'Y':
         return {type: target, segment: 0, year: period.year}


### PR DESCRIPTION
## Kontext

Nutzer-Feedback zur Tagesansicht der Energiedaten pro Zählpunkt:
> super wäre es, wenn man zum vorherigen bzw. nächsten Tag wechseln könnte (Pfeil rechts/links). Wenn die Auswahl des Tages außerhalb des Diagramms wäre, könnte man die Tage auswählen und sieht das Ergebnis parallel.

Zusätzlich soll der Tageschart standardmäßig auf den **Vortag** öffnen (die heutigen 15-Min-Daten sind noch unvollständig).

## Änderungen

**`MeterChartNavbar.component.tsx`**
- Prev/Next-Tag-Pfeile `‹ ›` links/rechts um das inline angezeigte Datum. Ein Klick = Tag ±1, ohne den Kalender zu öffnen — der Chart aktualisiert sich direkt.
- Pfeile sind auf denselben Abrechnungsperioden-Range beschränkt wie der Datepicker (#72) und werden an den Rändern deaktiviert (`prevDisabled`/`nextDisabled`).
- Das Kalender-Modal bleibt für weite Sprünge.

**`Helper.util.ts` (`createNewPeriod`, `'D'`-Zweig)**
- Default-Tag beim Wechsel in die Tagesansicht = **gestern** statt heute.

Chirurgisch, nur diese zwei Dateien (+ CHANGELOG). Keine Backend-/State-Änderung.

## Test

- `tsc --noEmit`: 0 Fehler.
- Vitest unverändert 10/12 (die 2 Fehlschläge = bekannte #69/#70 in `ParticipantPane.functions`/`FilterHelper.util`; kein Test referenziert `createNewPeriod`/`MeterChartNavbar`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
