### PR TITLE
fix(meter-chart): responsive day-view x-axis labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ this changelog highlights the changes relevant for overview and operations.
   preserving any prefix and zero-padding (`001→002`, `MG-001→MG-002`), and
   re-sync the form field once the member list resolves unless the user already
   edited it. Ported from an AGPL-3.0 sibling deployment.
+- Day view X-axis labels overlapped on narrow screens (e.g. Safari on mobile):
+  the fixed `interval={6}` rendered ~14 time labels regardless of width, which
+  fit on a wide desktop chart but ran together on a phone. Use responsive tick
+  thinning (`interval="preserveStartEnd"` + `minTickGap`) so recharts drops
+  labels to fit the available width.
 
 ## [1.0.4] – 2026-06-30
 

--- a/src/components/participantPane/MeterChart.component.tsx
+++ b/src/components/participantPane/MeterChart.component.tsx
@@ -131,7 +131,11 @@ const MeterChartComponent: FC<MeterChartComponentProps> = ({tenant, report, acti
               margin={{top: 5, right: 30, left: 20, bottom: 5}}
             >
               <CartesianGrid strokeDasharray="3 3"/>
-              <XAxis dataKey="name" interval={6} fontSize={10}/>
+              {/* Responsive tick density: a fixed interval crowds the labels on
+                  narrow screens (overlap on mobile) while fitting on wide ones.
+                  preserveStartEnd + minTickGap lets recharts drop labels to the
+                  available width, so it stays readable on phone and desktop. */}
+              <XAxis dataKey="name" interval="preserveStartEnd" minTickGap={20} fontSize={10}/>
               <YAxis fontSize={10} unit={" kWh"}/>
               <Tooltip formatter={(value) => Number(value).toFixed(3) + " kWh"}/>
               <Legend/>


### PR DESCRIPTION
## Problem

Nutzer-Feedback: Die X-Achsen-Beschriftung des Tages-Charts (Zählpunkt-Energiedaten) überlappt auf schmalen Bildschirmen (gemeldet auf Safari mobil) zu unlesbarem Textbrei. Auf Chrome/Desktop (breiter Bildschirm) passt es — vom Nutzer bestätigt: „beim funktionierenden Beispiel war der Bildschirm größer".

Ursache in `MeterChart.component.tsx`: der Tages-`LineChart` nutzt ein **festes** `interval={6}`, das unabhängig von der Chart-Breite ~14 Zeit-Labels (00:00, 01:45, 03:30 …) rendert. Breit = passt, schmal = Überlappung.

## Lösung

Responsives Tick-Thinning statt festem Interval:

```tsx
<XAxis dataKey="name" interval="preserveStartEnd" minTickGap={20} fontSize={10}/>
```

recharts reduziert die Label-Anzahl nach verfügbarer Breite — dicht auf Desktop, ausgedünnt (nicht überlappend) auf dem Handy. Start- und End-Label bleiben erhalten. Nur der Tages-Chart betroffen (einzige `interval`-Stelle im Repo).

## Test

- `tsc --noEmit`: 0 Fehler.
- Rein visuelle XAxis-Änderung; kein Test referenziert die Komponente.
- Sichtprüfung: schmales Viewport (DevTools/Handy) → keine Überlappung mehr; breit → weiterhin dicht.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
