### PR TITLE
fix(meter-chart): keep day-view date on a single line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ this changelog highlights the changes relevant for overview and operations.
   fit on a wide desktop chart but ran together on a phone. Use responsive tick
   thinning (`interval="preserveStartEnd"` + `minTickGap`) so recharts drops
   labels to fit the available width.
+- Day view date button wrapped onto three lines ("1." / "Jan." / "2023") next to
+  the new prev/next arrows: as a flex item it collapsed to min-content. Keep it on
+  a single line (`flexShrink: 0`) and let the day control size to its content
+  instead of the fixed 30% width used by the other period selectors.
 
 ## [1.0.4] – 2026-06-30
 

--- a/src/components/participantPane/MeterChartNavbar.component.tsx
+++ b/src/components/participantPane/MeterChartNavbar.component.tsx
@@ -106,32 +106,34 @@ const MeterChartNavbarComponent: FC<MeterChartNavbarComponentProps> = ({selected
           ))}
         </IonButtons>
       </div>
-      <div style={{width: "30%"}}>
-        {selectedPeriod?.type === 'D' ? (
-          <div style={{display: "flex", alignItems: "center", justifyContent: "center", gap: "4px"}}>
-            <IonButton fill="clear" size="small" onClick={() => stepDay(-1)} disabled={prevDisabled} aria-label="Vorheriger Tag">
-              <IonIcon slot="icon-only" icon={chevronBack}/>
-            </IonButton>
-            <IonDatetimeButton datetime="meter-day-datetime"/>
-            <IonButton fill="clear" size="small" onClick={() => stepDay(1)} disabled={nextDisabled} aria-label="Nächster Tag">
-              <IonIcon slot="icon-only" icon={chevronForward}/>
-            </IonButton>
-            <IonModal keepContentsMounted={true}>
-              <IonDatetime
-                id="meter-day-datetime"
-                presentation="date"
-                locale="de-DE"
-                value={currentDateValue}
-                min={hasDayRange ? minDate : undefined}
-                max={hasDayRange ? maxDate : undefined}
-                onIonChange={(e) => { if (typeof e.detail.value === 'string') onDateChange(e.detail.value) }}
-              />
-            </IonModal>
-          </div>
-        ) : (
+      {selectedPeriod?.type === 'D' ? (
+        <div style={{display: "flex", alignItems: "center", justifyContent: "center", gap: "4px"}}>
+          <IonButton fill="clear" size="small" onClick={() => stepDay(-1)} disabled={prevDisabled} aria-label="Vorheriger Tag">
+            <IonIcon slot="icon-only" icon={chevronBack}/>
+          </IonButton>
+          {/* flexShrink:0 keeps the date on a single line — as a flex item next to
+              the arrows it would otherwise collapse to min-content and wrap. */}
+          <IonDatetimeButton datetime="meter-day-datetime" style={{flexShrink: 0}}/>
+          <IonButton fill="clear" size="small" onClick={() => stepDay(1)} disabled={nextDisabled} aria-label="Nächster Tag">
+            <IonIcon slot="icon-only" icon={chevronForward}/>
+          </IonButton>
+          <IonModal keepContentsMounted={true}>
+            <IonDatetime
+              id="meter-day-datetime"
+              presentation="date"
+              locale="de-DE"
+              value={currentDateValue}
+              min={hasDayRange ? minDate : undefined}
+              max={hasDayRange ? maxDate : undefined}
+              onIonChange={(e) => { if (typeof e.detail.value === 'string') onDateChange(e.detail.value) }}
+            />
+          </IonModal>
+        </div>
+      ) : (
+        <div style={{width: "30%"}}>
           <PeriodSelectorElement periods={periods} activePeriod={selectedPeriod} onUpdatePeriod={onChangePeriod} />
-        )}
-      </div>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Problem

Durch die Prev/Next-Pfeile aus #75 bricht das Datumsfeld im Tages-Chart auf schmaleren Containern jetzt in **drei Zeilen** um ("1." / "Jan." / "2023") — vorher war es einzeilig. Ursache: `IonDatetimeButton` sitzt jetzt als Flex-Item neben den Pfeilen und kollabiert auf `min-content`-Breite, wodurch der Datumstext an den Leerzeichen umbricht. Zusätzlich deckelte der geerbte `width: 30%`-Container die Breite.

## Lösung (`MeterChartNavbar.component.tsx`)

- `flexShrink: 0` auf der `IonDatetimeButton` → bleibt einzeilig.
- Der `width: 30%`-Deckel gilt jetzt nur noch für den Perioden-Selektor der anderen Modi (Y/YH/YQ/YM); die Tages-Steuerung (Pfeile + Datum) richtet sich nach ihrem Inhalt.

Rein Layout, keine Logikänderung. Der größere Diff kommt nur vom Wegfall einer Verschachtelungsebene (Re-Indent).

## Test

- `tsc --noEmit`: 0 Fehler.
- Sichtprüfung: Datum wieder in einer Zeile, Pfeile links/rechts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
