### PR TITLE
fix(meter-chart): day-view default to period start for past periods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ this changelog highlights the changes relevant for overview and operations.
 
 ### Changed
 - Metering point day view now defaults to **yesterday** instead of today, because
-  today's 15-minute data is still incomplete when the view opens.
+  today's 15-minute data is still incomplete when the view opens. When a
+  **non-current billing period** is selected, it opens on that period's **first
+  day** (period start) instead of 1 January.
 
 ### Fixed
 - Member registration: the suggested next member number was derived from the

--- a/src/util/Helper.util.ts
+++ b/src/util/Helper.util.ts
@@ -160,12 +160,22 @@ export const createNewPeriod = (period: SelectedPeriod | undefined, target: Repo
   if (period !== undefined) {
     switch (target) {
       case 'D': {
-        // Default to yesterday, not today: today's 15-minute data is still
-        // incomplete, so the day view opens on the last fully-recorded day.
+        // Current period: default to yesterday, not today — today's 15-minute
+        // data is still incomplete, so open on the last fully-recorded day.
         const yesterday = new Date()
         yesterday.setDate(yesterday.getDate() - 1)
-        const sameYear = yesterday.getFullYear() === period.year
-        return {type: target, year: period.year, segment: sameYear ? dateToDayOfYear(yesterday) : 1}
+        if (yesterday.getFullYear() === period.year) {
+          return {type: target, year: period.year, segment: dateToDayOfYear(yesterday)}
+        }
+        // A non-current billing period: open on its first day (period start),
+        // not 1 January.
+        if (cpPeriod && cpPeriod.begin) {
+          const [day, month, year] = splitDate(cpPeriod.begin)
+          if (day && month && year) {
+            return {type: target, year, segment: dateToDayOfYear(new Date(year, month - 1, day))}
+          }
+        }
+        return {type: target, year: period.year, segment: 1}
       }
       case 'Y':
         return {type: target, segment: 0, year: period.year}


### PR DESCRIPTION
## Problem

In der Tagesansicht wurde beim Öffnen einer **nicht-aktuellen Abrechnungsperiode** der **1. Jänner** des Jahres vorausgewählt (z. B. „1. Jan. 2023") — nicht sinnvoll. Erwartet: der **erste Tag der gewählten Abrechnungsperiode**.

## Lösung (`Helper.util.ts`, `createNewPeriod` `'D'`-Zweig)

- **Aktuelle Periode** (gestern liegt im Jahr der Periode): unverändert → **gestern**.
- **Nicht-aktuelle Periode**: Default = **erster Tag der Periode** aus `cpPeriod.begin` (der Perioden-Range, der ohnehin schon an `createNewPeriod` übergeben wird) statt 1.1. Fällt begin nicht parsebar aus, bleibt der bisherige 1.1.-Fallback.

Nur diese eine Funktion. `cpPeriod.begin`/`.end` begrenzen bereits die Pfeile/den Datepicker, daher konsistent (der erste Tag = untere Range-Grenze).

## Test

- `tsc --noEmit`: 0 Fehler.
- Kein Test referenziert `createNewPeriod`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
