### PR TITLE
fix(meter-chart): even day-view x-axis label spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,9 @@ this changelog highlights the changes relevant for overview and operations.
 - Day view X-axis labels overlapped on narrow screens (e.g. Safari on mobile):
   the fixed `interval={6}` rendered ~14 time labels regardless of width, which
   fit on a wide desktop chart but ran together on a phone. Use responsive tick
-  thinning (`interval="preserveStartEnd"` + `minTickGap`) so recharts drops
-  labels to fit the available width.
+  thinning (`interval="preserveStart"` + `minTickGap`) so recharts drops labels
+  to fit the available width, with even spacing (`preserveStartEnd` forced the
+  last label and left an uneven gap before it).
 - Day view date button wrapped onto three lines ("1." / "Jan." / "2023") next to
   the new prev/next arrows: as a flex item it collapsed to min-content. Keep it on
   a single line (`flexShrink: 0`) and let the day control size to its content

--- a/src/components/participantPane/MeterChart.component.tsx
+++ b/src/components/participantPane/MeterChart.component.tsx
@@ -133,9 +133,10 @@ const MeterChartComponent: FC<MeterChartComponentProps> = ({tenant, report, acti
               <CartesianGrid strokeDasharray="3 3"/>
               {/* Responsive tick density: a fixed interval crowds the labels on
                   narrow screens (overlap on mobile) while fitting on wide ones.
-                  preserveStartEnd + minTickGap lets recharts drop labels to the
-                  available width, so it stays readable on phone and desktop. */}
-              <XAxis dataKey="name" interval="preserveStartEnd" minTickGap={20} fontSize={10}/>
+                  preserveStart + minTickGap keeps evenly-spaced labels that fit
+                  the width. (preserveStartEnd would force the last label (23:45)
+                  and leave an uneven gap before it.) */}
+              <XAxis dataKey="name" interval="preserveStart" minTickGap={20} fontSize={10}/>
               <YAxis fontSize={10} unit={" kWh"}/>
               <Tooltip formatter={(value) => Number(value).toFixed(3) + " kWh"}/>
               <Legend/>


### PR DESCRIPTION
## Problem

Nutzer-Feedback zur X-Achse des Tages-Charts: die Abstände wirken „komisch" — zwischen dem letzten gleichmäßig gesetzten Label (z. B. 17:15) und dem End-Label 23:45 klafft eine größere Lücke, in der eigentlich noch ein Label Platz hätte.

Ursache: `interval="preserveStartEnd"` **erzwingt** das letzte Label (23:45) und dünnt die Mitte per `minTickGap` aus. Dadurch wird ein Label kurz vor dem Ende weggelassen → unregelmäßige Lücke am rechten Rand.

## Lösung

`interval="preserveStart"` statt `preserveStartEnd`: Start bleibt fix, danach gleichmäßige, breitenabhängig ausgedünnte Abstände — **ohne** erzwungenes Endlabel. Ergebnis: durchgehend gleichmäßige Abstände (z. B. 00:00 · 05:45 · 11:30 · 17:15 · 23:00). Weiterhin responsiv über `minTickGap`.

## Test

- `tsc --noEmit`: 0 Fehler.
- Rein visuelle XAxis-Änderung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
