### PR TITLE
docs(changelog): stamp v1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ this changelog highlights the changes relevant for overview and operations.
 
 ## [Unreleased]
 
+## [1.0.5] – 2026-07-04
+
 ### Added
 - Metering point day view: previous/next-day arrows around the date, so you can
   step through days without opening the calendar and see the chart update in


### PR DESCRIPTION
Stamps `[Unreleased]` → `[1.0.5]` for the prod release.

Bundles the member-number suggestion fix (#74) and the day-view UX improvements (#75–79).

Promoted image: `ghcr.io/vfeeg-development/vfeeg-web:v1.0.5` == dev `latest` @ `b974015` (master HEAD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
