### PR TITLE
fix(meter-chart): DST-safe day-of-year so day-view arrows step correctly in summer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ this changelog highlights the changes relevant for overview and operations.
 ### Changed
 - CI: Preview-Deployments (ADR-0007) — Push auf `preview/**` baut+deployt on-demand in die Dev-Zone (sha-pinned, kein `:latest`), Auto-Reset bei Branch-Delete.
 
+### Fixed
+- Day view previous/next-day arrows stepped wrong in **summer** (any date after
+  the spring-forward DST change, e.g. reported in prod on June dates): forward got
+  stuck on the same day and backward jumped two days. `dateToDayOfYear` counted
+  days by dividing wall-clock milliseconds by 24h, which loses a day once a 23h
+  DST day sits between 1 January and the date. Count calendar days via `Date.UTC`
+  instead (DST-immune). Winter was unaffected, which is why it only showed on
+  current-period (summer) data. Added a regression test that runs under
+  `Europe/Vienna` and round-trips every day of the year across the DST boundary. (#67)
+
 ## [1.0.5] – 2026-07-04
 
 ### Added

--- a/src/__test__/utils/Helper.util.dst.test.ts
+++ b/src/__test__/utils/Helper.util.dst.test.ts
@@ -1,0 +1,29 @@
+// Force a DST timezone so the day-of-year round-trip is exercised across the
+// CET->CEST change. The day-view arrows stepped by 2 days (and got stuck the
+// other direction) in summer because dateToDayOfYear divided wall-clock ms by
+// 24h, losing a day once a 23h DST day sat between Jan 1 and the date.
+process.env.TZ = 'Europe/Vienna'
+
+import { describe, it, expect } from "vitest"
+import { dateToDayOfYear, dayOfYearToDate } from "../../util/Helper.util"
+
+describe("dateToDayOfYear / dayOfYearToDate (DST-safe)", () => {
+  it("round-trips every day of a non-leap and a leap year, incl. across DST", () => {
+    for (const year of [2023, 2024]) {
+      const days = year % 4 === 0 ? 366 : 365
+      for (let doy = 1; doy <= days; doy++) {
+        expect(dateToDayOfYear(dayOfYearToDate(year, doy))).toBe(doy)
+      }
+    }
+  })
+
+  it("steps exactly one day forward and back on a summer date (CEST)", () => {
+    // 19 Jun 2026 is CEST (+2), an hour ahead of the Jan 1 CET (+1) baseline —
+    // the case that broke the day-view navigation.
+    const seg = dateToDayOfYear(new Date(2026, 5, 19))
+    const next = dayOfYearToDate(2026, seg); next.setDate(next.getDate() + 1)
+    const prev = dayOfYearToDate(2026, seg); prev.setDate(prev.getDate() - 1)
+    expect(dateToDayOfYear(next)).toBe(seg + 1)
+    expect(dateToDayOfYear(prev)).toBe(seg - 1)
+  })
+})

--- a/src/util/Helper.util.ts
+++ b/src/util/Helper.util.ts
@@ -96,9 +96,13 @@ export const dayOfYearToDate = (year: number, dayOfYear: number) => {
 }
 
 export const dateToDayOfYear = (d: Date) => {
-  const start = new Date(d.getFullYear(), 0, 1, 0, 0, 0, 0)
-  const diff = d.getTime() - start.getTime()
-  return Math.floor(diff / (24 * 60 * 60 * 1000)) + 1
+  // Count whole calendar days via UTC to stay DST-safe: subtracting wall-clock
+  // timestamps and dividing by 24h loses a day once a DST change (e.g. Europe/
+  // Vienna CET→CEST) puts a 23h day between Jan 1 and the date, which shifted
+  // the day-view navigation by a day in summer.
+  const start = Date.UTC(d.getFullYear(), 0, 1)
+  const cur = Date.UTC(d.getFullYear(), d.getMonth(), d.getDate())
+  return Math.round((cur - start) / (24 * 60 * 60 * 1000)) + 1
 }
 
 // Format a Date as YYYY-MM-DD from its LOCAL components. Avoids the UTC shift of


### PR DESCRIPTION
## Problem

Die Tagesansicht-Pfeile (vor/zurück) verhalten sich **im Sommer** falsch — konkret für jedes Datum **nach der Frühjahrs-Zeitumstellung**. In prod (Juni-Daten) berichtet: **vorwärts bleibt auf demselben Tag stehen, rückwärts springt 2 Tage**. Im Winter (der dev-Test lief mit Januar-Daten) tritt es nicht auf — das hat den Bug maskiert und wie ein dev-vs-prod-Unterschied aussehen lassen.

## Ursache

`dateToDayOfYear` zählt Tage als `floor(wall-clock-ms / 24h)`. Sobald zwischen dem 1. Januar (Winterzeit) und dem Datum ein 23-h-DST-Tag liegt, ist die Millisekunden-Differenz eine Stunde zu kurz und das Ergebnis kippt um einen Tag. Der Day-of-Year-Round-Trip in `stepDay` driftet dadurch im Sommer.

Reproduziert am echten Helper unter `Europe/Vienna`:
```
SOMMER next: seg 170→170→170   (bleibt stehen)
SOMMER prev: seg 170→168→166   (−2 pro Klick)
WINTER:      seg   1→2→3→4      (korrekt)
```

## Fix

Ganze Kalendertage über `Date.UTC(y, m, d)` der lokalen Komponenten zählen — UTC kennt keine Sommerzeit, also DST-immun. `dayOfYearToDate` (nutzt `setDate`) war bereits sicher; nur `dateToDayOfYear` war das Leck.

## Test

Neuer Regressionstest (`Helper.util.dst.test.ts`) unter `TZ=Europe/Vienna`:
- Round-Trip für **jeden** Tag eines Schalt- und Nicht-Schaltjahres (fällt auf altem Code an der März-DST-Grenze, Tag 85/86).
- exakter ±1-Tag-Schritt auf einem Sommertag.

Verifiziert: schlägt auf altem Code fehl (`erwartet 86, war 85` / `170 vs 169`), grün mit Fix. Restliche Unit-Suite unverändert (der vorbestehende `FilterHelper`-Fehlschlag ist unabhängig und war schon auf `master` rot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)