### PR TITLE
feat(billing-config): remove "Abrechnungsinfo statt Gutschrift für Firmen" option (web)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ this changelog highlights the changes relevant for overview and operations.
 
 ### Changed
 - CI: Preview-Deployments (ADR-0007) — Push auf `preview/**` baut+deployt on-demand in die Dev-Zone (sha-pinned, kein `:latest`), Auto-Reset bei Branch-Delete.
+- Billing config: removed the "Erzeuge Gutschriften für UST-pflichtige Erzeuger" toggle.
+  UST-registered producers (companies) now always receive the reverse-charge credit note; the
+  "Abrechnungsinfo" variant is no longer offered. `createCreditNotesForAllProducers` is now sent
+  as `true` on both create and update of the billing config (the primitive-boolean field would
+  otherwise fall back to `false` on save and re-enable the info document). The three
+  "Abrechnungsinfos: …" text fields are relabeled "Gutschriften für Firmen: …" — same fields,
+  they feed the reverse-charge credit note. (Existing EEGs still on the old setting are switched
+  over by a one-off DB update; billing service, document type and schema are unchanged, so
+  historical info documents stay intact.)
 
 ### Fixed
 - Day view previous/next-day arrows stepped wrong in **summer** (any date after

--- a/src/components/EegBillingConfigCard.component.tsx
+++ b/src/components/EegBillingConfigCard.component.tsx
@@ -1,5 +1,5 @@
 import React, {FC, useEffect, useState} from "react";
-import {Controller, useForm} from "react-hook-form";
+import {useForm} from "react-hook-form";
 import {BillingConfig} from "../models/eeg.model";
 import {
     IonButton,
@@ -7,8 +7,7 @@ import {
     IonChip,
     IonIcon,
     IonImg,
-    IonItem,
-    IonLabel, IonToggle,
+    IonLabel,
     useIonPopover,
     useIonToast
 } from "@ionic/react";
@@ -186,15 +185,15 @@ const EegBillingConfigCardComponent: FC = () => {
                                                 type="number" readonly={!isAdmin()}/>
 
                             <InputForm name={"beforeItemsTextInfo"}
-                                                label="Abrechnungsinfos: Text vor Positionen"
+                                                label="Gutschriften für Firmen: Text vor Positionen"
                                                 control={control}
                                                 type="text" readonly={!isAdmin()}/>
                             <InputForm name={"afterItemsTextInfo"}
-                                                label="Abrechnungsinfos: Text nach Positionen"
+                                                label="Gutschriften für Firmen: Text nach Positionen"
                                                 control={control}
                                                 type="text" readonly={!isAdmin()}/>
                             <InputForm name={"termsTextInfo"}
-                                                label="Abrechnungsinfos: Abschlusstext"
+                                                label="Gutschriften für Firmen: Abschlusstext"
                                                 control={control}
                                                 type="text" readonly={!isAdmin()}/>
 
@@ -208,24 +207,6 @@ const EegBillingConfigCardComponent: FC = () => {
                                                 rules={{min: 1, max: 6}}
                                                 control={control}
                                                 type="number" readonly={!isAdmin()}/>
-                            <IonItem lines="none">
-                                <Controller
-                                    name={"createCreditNotesForAllProducers"}
-                                    control={control}
-                                    render={({field}) => {
-                                        const {onChange, value} = field;
-                                        return (<IonToggle
-                                            style={{width: "100%"}}
-                                            slot="start"
-                                            labelPlacement="start"
-                                            checked={value}
-                                            onIonChange={(e) => {
-                                                onChange(e.detail.checked);
-                                            }}>Erzeuge Gutschriften für UST-pflichtige Erzeuger</IonToggle>)
-                                        }
-                                    }
-                                />
-                            </IonItem>
                         </form>
                     }
 

--- a/src/service/eeg.service.ts
+++ b/src/service/eeg.service.ts
@@ -307,7 +307,8 @@ export class EegService extends EegBaseService {
         "Content-Type": "application/json",
       },
       body: JSON.stringify({tenantId : tenant, invoiceNumberStart : 0,
-        creditNoteNumberStart: 0, documentNumberSequenceLength: 5} as BillingConfig)
+        creditNoteNumberStart: 0, documentNumberSequenceLength: 5,
+        createCreditNotesForAllProducers: true} as BillingConfig)
     }).then(this.handleErrors).then(res => res.json())
 
     return await result.then(
@@ -329,7 +330,10 @@ export class EegService extends EegBaseService {
         'Accept': 'application/json',
         "Content-Type": "application/json",
       },
-      body: JSON.stringify(billingConfig)
+      // Abrechnungsinfo-Option entfällt: UST-pflichtige Erzeuger bekommen immer die
+      // RC-Gutschrift. Das Flag hat kein UI mehr; hier fix true senden, sonst würde das
+      // primitive boolean serverseitig auf false zurückfallen (BillingConfig full overwrite).
+      body: JSON.stringify({...billingConfig, createCreditNotesForAllProducers: true})
     }).then(this.handleErrors).then(res => {});
 
     return this.fetchBillingConfigById(billingConfig.id, tenant, token);


### PR DESCRIPTION
Setzt den Web-Teil aus `konzept-abrechnungsinfo-entfernen.md` um: Firmen (UST-pflichtige Erzeuger) bekommen künftig **immer** die Reverse-Charge-Gutschrift; die „Abrechnungsinfo"-Variante entfällt.

## Änderungen (nur Web)
- **`eeg.service.ts`:** `createCreditNotesForAllProducers=true` bei **Create und Update** der Billing-Config senden. Das billing-DTO-Feld ist ein primitives `boolean` und `BillingConfigService` überschreibt die Entität beim Speichern komplett — ein fehlender/`false`-Wert würde die Abrechnungsinfo sonst wieder aktivieren.
- **`EegBillingConfigCard`:** Umschalter „Erzeuge Gutschriften für UST-pflichtige Erzeuger" entfernt; verwaiste `Controller`/`IonItem`/`IonToggle`-Imports entfernt.
- **Labels** der drei Info-Textfelder von „Abrechnungsinfos: …" → „Gutschriften für Firmen: …" (gleiche Felder `before/afterItemsTextInfo`, `termsTextInfo` — sie speisen die RC-Gutschrift).

## Bewusst NICHT enthalten
- **Kein billing-/backend-Change:** Dokumenttyp, `INFO`-Enum und Schema bleiben — historische Info-Dokumente bleiben intakt.
- **DB-Umstellung** der verbleibenden EEGs (`is_create_credit_notes_for_all_producers` false→true) erfolgt als **Operator-One-off** (Runbook), nicht hier.

## Verifikation
- `tsc --noEmit` grün.
- Unit-Suite: keine neue Regression (die zwei vorbestehenden Fehlschläge `FilterHelper`/`ParticipantPane.functions` bestehen unverändert auch auf `master`; werden separat repariert).

Konzept + Tech-Design: `konzept-abrechnungsinfo-entfernen.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)