### PR TITLE
test(web): repair two stale unit tests (FilterHelper, ParticipantPane.functions)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ this changelog highlights the changes relevant for overview and operations.
   instead (DST-immune). Winter was unaffected, which is why it only showed on
   current-period (summer) data. Added a regression test that runs under
   `Europe/Vienna` and round-trips every day of the year across the DST boundary. (#67)
+- Repaired two stale unit tests (`FilterHelper.util`, `ParticipantPane.functions`) that had drifted
+  from the code they cover: `filterActiveParticipantAndMeter` now gets realistic meter `status` and
+  the call-site `.filter(p => p.meters.length > 0)`; `buildAllocationMapFromSelected` reads the
+  energy report from the store, so the test mocks the store and asserts current behaviour
+  (zero-kWh meters included, `participantId` present). Test-only — no production change.
 
 ## [1.0.5] – 2026-07-04
 

--- a/src/__test__/components/participantPane/ParticipantPane.functions.test.tsx
+++ b/src/__test__/components/participantPane/ParticipantPane.functions.test.tsx
@@ -1,12 +1,27 @@
+import { describe, it, expect, vi } from "vitest";
 import {AccountInfo, Address, Contact, Optionals} from "../../../models/eeg.model";
 import {Metering} from "../../../models/meteringpoint.model";
-import {buildAllocationMapFromSelected} from "../../../components/participantPane/ParticipantPane.functions";
 import {EegParticipant} from "../../../models/members.model";
 
-describe("<ParticipantPane/> Functions", () => {
-  beforeAll(() => {
-  })
+// buildAllocationMapFromSelected reads the per-participant energy report from the
+// redux store (meteringEnergyGroup1), not from an argument. Mock both so the unit
+// test is deterministic without booting the store.
+vi.mock("../../../store", () => ({store: {getState: () => ({})}}));
+vi.mock("../../../store/energy", () => ({
+  meteringEnergyGroup1: () => [
+    {
+      participantId: "1234567890",
+      meters: [
+        {meterId: "AT0000000000000000000000000000001", meterDir: "CONSUMPTION", report: {summary: {utilization: 10, production: 0, allocation: 0}}},
+        {meterId: "AT0000000000000000000000000000002", meterDir: "CONSUMPTION", report: {summary: {utilization: 0, production: 0, allocation: 0}}},
+      ],
+    },
+  ],
+}));
 
+import {buildAllocationMapFromSelected} from "../../../components/participantPane/ParticipantPane.functions";
+
+describe("<ParticipantPane/> Functions", () => {
   it("allocate invoice member and metering points", async () => {
     const participants = [{
       accountInfo: {} as AccountInfo,
@@ -39,10 +54,15 @@ describe("<ParticipantPane/> Functions", () => {
     ]
 
     const checkedParticipants = {"1234567890": true}
-    const meterGroup = {"AT0000000000000000000000000000001": 10, "AT0000000000000000000000000000002": 0}
 
     const r = buildAllocationMapFromSelected(participants, checkedParticipants)
-    expect(r.length).toEqual(1)
-    expect(r).toEqual([{meteringPoint: 'AT0000000000000000000000000000001', allocationKWh: 10}])
+
+    // Current behaviour: energy comes from the store; zero-kWh meters are NOT
+    // filtered out (the >0 filter is intentionally disabled) and each entry
+    // carries the participantId.
+    expect(r).toEqual([
+      {participantId: "1234567890", meteringPoint: "AT0000000000000000000000000000001", allocationKWh: 10},
+      {participantId: "1234567890", meteringPoint: "AT0000000000000000000000000000002", allocationKWh: 0},
+    ])
   });
 })

--- a/src/__test__/utils/FilterHelper.util.test.ts
+++ b/src/__test__/utils/FilterHelper.util.test.ts
@@ -1,30 +1,30 @@
-import {splitDate} from "../../util/Helper.util";
 import {EegParticipant} from "../../models/members.model";
 import {Metering, ParticipantState} from "../../models/meteringpoint.model";
 import {filterActiveParticipantAndMeter} from "../../util/FilterHelper.unit";
 import { describe, it, expect } from "vitest";
 
+// Real meters always carry a `status` (INIT|ACTIVE|INACTIVE); the ACTIVE/INACTIVE
+// date window only governs non-INIT meters. Fully-inactive participants are dropped
+// at the call site via `.filter(p => p.meters.length > 0)` (see ParticipantPane),
+// so these tests mirror that end-to-end usage.
+const activeParticipants = (ps: EegParticipant[], start: Date, end: Date) =>
+  filterActiveParticipantAndMeter(ps, start, end).filter(p => p.meters.length > 0)
 
-const getDate = (y: number, m: number, d: number) => new Date(y, m, d)
+const participants = (): EegParticipant[] => [
+  {id:"1", meters: [{meteringPoint:"AT1111111111111111111111111", status: "ACTIVE", processState: "ACTIVE", participantState: {activeSince: new Date(2024, 0, 31), inactiveSince: new Date(2077, 11, 31)} as ParticipantState} as Metering]} as EegParticipant,
+  {id:"2", meters: [{meteringPoint:"AT1111111111111111111111112", status: "ACTIVE", processState: "INACTIVE", participantState: {activeSince: new Date(2024, 0, 31), inactiveSince: new Date(2024, 2, 31)} as ParticipantState} as Metering]} as EegParticipant
+]
 
 describe("Filter Helpers", () => {
   it("filter active participants and meters (all)", async () => {
-    const participants = [
-      {id:"1", meters: [{meteringPoint:"AT1111111111111111111111111", processState: "ACTIVE", participantState: {activeSince: new Date(2024, 0, 31), inactiveSince: new Date(2077, 11, 31)} as ParticipantState} as Metering]} as EegParticipant,
-      {id:"2", meters: [{meteringPoint:"AT1111111111111111111111112", processState: "INACTIVE", participantState: {activeSince: new Date(2024, 0, 31), inactiveSince: new Date(2024, 2, 31)} as ParticipantState} as Metering]} as EegParticipant
-    ]
-
-    const filtered = filterActiveParticipantAndMeter(participants, new Date(2024, 0, 31), new Date(2024, 5, 20))
-    expect(filtered).toEqual(participants)
+    const ps = participants()
+    // Period Jan–Jun 2024: participant 2's meter is still active at the start (inactive 31 Mar) → kept.
+    expect(activeParticipants(ps, new Date(2024, 0, 31), new Date(2024, 5, 20))).toEqual(ps)
   });
 
   it("filter active participants and meters (1)", async () => {
-    const participants = [
-      {id:"1", meters: [{meteringPoint:"AT1111111111111111111111111", processState: "ACTIVE", participantState: {activeSince: new Date(2024, 0, 31), inactiveSince: new Date(2077, 11, 31)} as ParticipantState} as Metering]} as EegParticipant,
-      {id:"2", meters: [{meteringPoint:"AT1111111111111111111111112", processState: "INACTIVE", participantState: {activeSince: new Date(2024, 0, 31), inactiveSince: new Date(2024, 2, 31)} as ParticipantState} as Metering]} as EegParticipant
-    ]
-
-    const filtered = filterActiveParticipantAndMeter(participants, new Date(2024, 3, 1), new Date(2024, 5, 20))
-    expect(filtered).toEqual([participants[0]])
+    const ps = participants()
+    // Period Apr–Jun 2024: participant 2's meter went inactive 31 Mar → dropped.
+    expect(activeParticipants(ps, new Date(2024, 3, 1), new Date(2024, 5, 20))).toEqual([ps[0]])
   });
 })


### PR DESCRIPTION
Zwei Unit-Tests waren auf `master` rot (unabhängig von anderen PRs). Beide prüften einen **älteren Vertrag** von weiterhin genutzten, **abrechnungsrelevanten** Funktionen. Bewusste Entscheidung: **nur die Tests** ans aktuelle Verhalten anpassen — **kein** Produktivcode ändern (das würde Allocation/Filterung und damit die Abrechnung beeinflussen).

## FilterHelper.util (`filterActiveParticipantAndMeter`)
- Testdaten setzten nur `processState`, nicht `status`. Die Funktion behält INIT-Zähler über einen `status`-Fallback; mit `status = undefined` griff der Fallback fälschlich.
- Das Wegfiltern leerer Teilnehmer sitzt inzwischen **am Aufrufort** (`ParticipantPane`), nicht in der Funktion.
- **Fix:** realistisches `status: "ACTIVE"` in die Fixtures + Call-Site-Filter `.filter(p => p.meters.length > 0)` spiegeln.

## ParticipantPane.functions (`buildAllocationMapFromSelected`)
- Funktion liest die Energiedaten heute aus dem **Redux-Store** (`meteringEnergyGroup1`), nicht aus einem Argument (die alte `meterGroup`-Variable war toter Code).
- **Fix:** Store + Selektor mocken; Erwartung an aktuelles Verhalten angleichen — **0-kWh-Zähler inklusive** (der `>0`-Filter ist bewusst auskommentiert), `participantId` je Eintrag.

Verhalten der 0-kWh-Zähler wurde als **gewollt** bestätigt (Operator-Entscheidung).

Verifikation: `tsc` grün; volle Unit-Suite **14/14 grün**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)