### PR TITLE
feat(billing-config): Mitgliedstyp-Labels für Gutschriftentexte + deutscher Rechtschreib-Sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ this changelog highlights the changes relevant for overview and operations.
   they feed the reverse-charge credit note. (Existing EEGs still on the old setting are switched
   over by a one-off DB update; billing service, document type and schema are unchanged, so
   historical info documents stay intact.)
+- Billing config: the credit-note text fields are now labeled by member type —
+  "Gutschriften für Mitgliedstyp Privat: …" (producers without a VAT ID) and
+  "Gutschriften für Mitgliedstyp Firma: …" (VAT-registered, reverse-charge) — so it is clear
+  which member type drives the assignment (the tariff models will follow the same Firma/Privat split).
 
 ### Fixed
 - Day view previous/next-day arrows stepped wrong in **summer** (any date after
@@ -34,6 +38,14 @@ this changelog highlights the changes relevant for overview and operations.
   the call-site `.filter(p => p.meters.length > 0)`; `buildAllocationMapFromSelected` reads the
   energy report from the store, so the test mocks the store and asserts current behaviour
   (zero-kWh meters included, `participantId` present). Test-only — no production change.
+- German UI text: spelling/grammar corrections across the German locale resources
+  (`locales/de/common.json`, `error.json`) and several components — real typos
+  (Steuernummer, Periode, vorhanden, Aktivierungs-Code, Produktion), missing inflection
+  (Mitgliedsbeitrag, Mandatsreferenz, "des Teilnahmefaktors", "mit den Marktpartnern",
+  "wenn alle Daten", polite "Ihren"), and compound spacing/hyphenation (Zählpunktgebühr,
+  Kontaktperson, Kontoinhaber, Filteroptionen, Netzbetreiber-ID, Gemeinschafts-ID,
+  Online-/Offline-Registrierung, E-Mail-Adresse, USt., SEPA). Billing config card additionally:
+  "führenden Nullen", "z. B.", "Rechnungsnummern". Text-only — no logic change. (Fable spell-audit)
 
 ## [1.0.5] – 2026-07-04
 

--- a/locales/de/common.json
+++ b/locales/de/common.json
@@ -4,8 +4,8 @@
   "company-name": "Firmenname",
   "grid-operator": {
     "header": "Netzbetreiber",
-    "id": "Netzbetreiber ID",
-    "name": "Netzbetreiber Name"
+    "id": "Netzbetreiber-ID",
+    "name": "Netzbetreiber-Name"
   },
   "participant": "Mitglied",
   "participant-nr": "Mitglieds-Nr",
@@ -17,8 +17,8 @@
   "participant-title_company": "Firma",
   "participant-title_privat": "Privat",
   "participant_tariff": "Mitglieds-Tarif",
-  "participantFee": "Mitgliedbeitrag in € (je Abrechnungsintervall, netto)",
-  "participantFee_card": "Mitgliedbeitrag",
+  "participantFee": "Mitgliedsbeitrag in € (je Abrechnungsintervall, netto)",
+  "participantFee_card": "Mitgliedsbeitrag",
   "metering": "Zählpunkt",
   "tariff": "Tarif",
   "tariffLabel": "Tarifbezeichnung",
@@ -29,7 +29,7 @@
   "inverternr_label": "Wechselrichternummer",
   "transformer_label": "Transformator",
   "equipmentNumber_label": "Anlagen-Nr.",
-  "equipmentName_label": "Anlagename",
+  "equipmentName_label": "Anlagenname",
   "vatSupplementaryText": "Zusatztext für Umsatzsteuer",
   "discount": "Rabatt in %",
   "discount_card": "Rabatt",
@@ -38,9 +38,9 @@
   "centPerKWh_card": "Cent pro kWh",
   "freeKWh": "Kostenlose Energie in kWh (je Abrechnungsintervall)",
   "freeKWh_card": "Inklusive kWh",
-  "useMeteringPointFee": "Zählpunkt Gebühr einheben?",
+  "useMeteringPointFee": "Zählpunktgebühr einheben?",
   "meteringPointFee": "Zählpunktgebühr in €",
-  "meteringPointVat": "Ust. für Zählpunktgebühr in %",
+  "meteringPointVat": "USt. für Zählpunktgebühr in %",
   "meteringPointFee_card": "Zählpunktgebühr",
   "meteringPoint-active-since": "Aktiv seit ...",
   "useVat": "Umsatzsteuer anführen",
@@ -67,25 +67,25 @@
   },
   "contact": {
     "header": "Kontakt",
-    "person": "Kontakt Person"
+    "person": "Kontaktperson"
   },
   "account": {
     "header": "Bankdaten",
     "owner": "Kontoinhaber",
     "name": "Bankverbindung",
-    "mandate-reference": "Mandatreferenz",
-    "mandate-date": "Mandatdatum",
-    "creditor-id": "Creditor ID",
+    "mandate-reference": "Mandatsreferenz",
+    "mandate-date": "Mandatsdatum",
+    "creditor-id": "Creditor-ID",
     "bic": "BIC",
     "sepaDirectDebit": "Einzugsart",
-    "sepaDebitOption_none": "Kein Sepa",
+    "sepaDebitOption_none": "Kein SEPA",
     "sepaDebitOption_b2b": "B2B",
     "sepaDebitOption_core": "CORE"
   },
   "common-info": {
     "header": "Allgemeines",
     "ec-number": "EC-Nummer",
-    "community-id": "Gemeinschafts ID",
+    "community-id": "Gemeinschafts-ID",
     "legal": {
       "label": "Rechtsform",
       "verein": "Verein",
@@ -100,8 +100,8 @@
     "allocation-mode": "Verteilung"
   },
   "warnings": {
-    "email_missing": "Email Adresse fehlt!",
-    "email_wrong": "Email Adresse ist nicht valide!",
+    "email_missing": "E-Mail-Adresse fehlt!",
+    "email_wrong": "E-Mail-Adresse ist nicht valide!",
     "firstname_missing": "Vorname fehlt!",
     "lastname_missing": "Nachname fehlt!",
     "company-name_missing": "Firmenname fehlt!",
@@ -111,21 +111,21 @@
     "street-number_missing": "Hausnummer fehlt!",
     "account-owner_missing": "Kontoinhaber fehlt!",
     "account-name_missing": "Bankverbindung fehlt!",
-    "account-mandate_reference_missing": "Mandatreferenz fehlt!",
-    "gridoperator-id_missing": "Netzbetreiber-Id fehlt!",
-    "gridoperator-id_length": "Netzbetreiber-Id besteht aus 8 Zeichen",
+    "account-mandate_reference_missing": "Mandatsreferenz fehlt!",
+    "gridoperator-id_missing": "Netzbetreiber-ID fehlt!",
+    "gridoperator-id_length": "Netzbetreiber-ID besteht aus 8 Zeichen",
     "gridoperator-name_missing": "Netzbetreiber-Name fehlt!",
     "partition-factor_missing": "Teilnehmerfaktor fehlt!",
     "allocation-factor_missing": "Verteilungsfaktor fehlt!",
     "metering_missing_msg": "Zählpunktnummer fehlt!",
     "fee_missing": "Gebühr fehlt!",
-    "vat_missing": "Ust. fehlt!",
+    "vat_missing": "USt. fehlt!",
     "vat_zero": "0% nicht erlaubt!",
     "vat_to_big": "Nur 100% erlaubt!"
   },
   "alerts": {
-    "changeDirection_0": "Energierichtung zu einen $t(producer) ändern? Es gilt zu beachten, dass diese Änderung nicht mit dem Netzbetreiber kommuniziert wird. Die Änderung wird nur in EEGFaktura vollzogen und hat keine Auswirkung beim Netzbetreiber!",
-    "changeDirection_1": "Energierichtung zu einen $t(consumer) ändern? Es gilt zu beachten, dass diese Änderung nicht mit dem Netzbetreiber kommuniziert wird. Die Änderung wird nur in EEGFaktura vollzogen und hat keine Auswirkung beim Netzbetreiber!",
+    "changeDirection_0": "Energierichtung zu einem $t(producer) ändern? Es gilt zu beachten, dass diese Änderung nicht mit dem Netzbetreiber kommuniziert wird. Die Änderung wird nur in EEGFaktura vollzogen und hat keine Auswirkung beim Netzbetreiber!",
+    "changeDirection_1": "Energierichtung zu einem $t(consumer) ändern? Es gilt zu beachten, dass diese Änderung nicht mit dem Netzbetreiber kommuniziert wird. Die Änderung wird nur in EEGFaktura vollzogen und hat keine Auswirkung beim Netzbetreiber!",
     "changeBusinessType_0": "Den Business-Typ ändern? Nach der Änderung wird der Vorname des Mitglieds als Firmenname übernommen. Bitte den Firmennamen im entsprechenden Feld anpassen!",
     "changeBusinessType_1": "Den Business-Typ ändern? Nach der Änderung bleibt das Nachnamen-Feld des Mitglieds leer. Bitte anschließend den Nachnamen in das entsprechende Feld eintragen!"
   },
@@ -138,16 +138,16 @@
   "process": {
     "submit": "Anfordern",
     "requestValue": {
-      "selectEntire": "Zählpunkte für Gesamte EEG nachfordern"
+      "selectEntire": "Zählpunkte für die gesamte EEG nachfordern"
     },
     "partFact": {
-      "label": "Teilnehmer Faktor in %",
-      "title": "Teilnehmer Faktor ändern",
+      "label": "Teilnehmerfaktor in %",
+      "title": "Teilnehmerfaktor ändern",
       "desc": "Mit diesem Prozess kann der Teilnahmefaktor von aktiven Zählpunkten geändert werden. Zulässig ist eine Änderung pro Tag und je Energiegemeinschaft und Zählpunkt. Diese Änderung liegt in der Verantwortung der Energiegemeinschaft."
     },
     "allocationFactor": {
-      "label": "Verteilungs Faktor in %",
-      "title": "Verteilungs Faktor ändern",
+      "label": "Verteilungsfaktor in %",
+      "title": "Verteilungsfaktor ändern",
       "desc": "Mit diesem Prozess kann der Verteilungsfaktor von aktiven Zählpunkten geändert werden."
     },
     "podList": {
@@ -166,14 +166,14 @@
     },
     "history": {
       "title": "Prozess History",
-      "desc": "Übersicht der Prozesskommunikation mit den Marktpartner."
+      "desc": "Übersicht der Prozesskommunikation mit den Marktpartnern."
     },
     "revokeMeter": {
       "title": "Zählpunkt abmelden",
       "desc": "Der Marktteilnehmer wird über die Aufhebung einer erteilten Datenfreigabe in Kenntnis gesetzt.",
       "reason": "Begründung (optional)"
     },
-    "EC_PRTFACT_CHANGE": "Änderung des Teilnahmefaktor",
+    "EC_PRTFACT_CHANGE": "Änderung des Teilnahmefaktors",
     "EC_REQ_ONL": "Anmeldung Teilnahme Online",
     "CR_REQ_PT": "Anfordern von Energiedaten",
     "CR_MSG": "Versenden der Energiedaten",
@@ -214,14 +214,14 @@
     "status_text_NEW": "Antwort des Netzbetreibers noch ausstehend.",
     "status_text_INIT": "Antwort des Netzbetreibers noch ausstehend.",
     "status_text_PENDING": "Zustimmung des Mitglieds noch ausstehend.",
-    "status_text_APPROVED": "Abschluss Meldung von Netzbetreiber noch ausstehend.",
+    "status_text_APPROVED": "Abschlussmeldung vom Netzbetreiber noch ausstehend.",
     "status_text_REJECTED": "Zählpunkt wurde vom Netzbetreiber abgewiesen.",
     "status_text_REVOKED": "Zählpunkt wurde vom Netzbetreiber aufgehoben.",
     "status_text_INVALID": "Zählpunkt wurde vom Netzbetreiber nicht angenommen.",
     "status_text_INACTIVE": "Zählpunkt INAKTIV."
   },
   "meterlist": {
-    "filter_header": "Filter Optionen:",
+    "filter_header": "Filteroptionen:",
     "filter_text_rejected": "Abgewiesene",
     "filter_text_init": "Ausstehende",
     "filter_text_inactive": "Inaktive"

--- a/locales/de/error.json
+++ b/locales/de/error.json
@@ -1,9 +1,9 @@
 {
   "E_2055_participant_update" : "Die gewünschte Eigenschaft konnte nicht erneuert werden.",
-  "E_1000_eeg_load": "Fehler beim laden der EEG Basisdaten!",
+  "E_1000_eeg_load": "Fehler beim Laden der EEG-Basisdaten!",
   "E_1001_eeg_load": "Die EEG wurde noch nicht angelegt!",
   "E_1002_Process_eeg_load": "Bad process",
-  "E_1000_no_entries": "Keine Energiedaten für diese Peroide gefunden!",
+  "E_1000_no_entries": "Keine Energiedaten für diese Periode gefunden!",
   "E_1021_tariff_create": "Tarif konnte nicht generiert werden.",
   "intern": {
     "empty_eeg": "Keine aktive EEG geladen"
@@ -12,9 +12,9 @@
   "process": {
     "podList_ok": "Zählpunktliste konnte erfolgreich angefordert werden.",
     "podList_error": "Zählpunktliste konnte nicht erfolgreich angefordert werden.",
-    "revoke_consentIdEmpty": "Für diesen Zählpunkt fehlt noch die Consent-ID. Ohne dieser Information kann der Abmeldeprozess nicht ausgeführt werden. Versuchen Sie die Teilnehmerliste anzufordern, damit die Consent-ID mit den Zählpunkten abgeglichen werden kann."
+    "revoke_consentIdEmpty": "Für diesen Zählpunkt fehlt noch die Consent-ID. Ohne diese Information kann der Abmeldeprozess nicht ausgeführt werden. Versuchen Sie die Teilnehmerliste anzufordern, damit die Consent-ID mit den Zählpunkten abgeglichen werden kann."
   },
-  "E_BIC_MISSING": "Die BIC der EEG wurde noch nicht konfiguriert",
-  "E_IBAN_MISSING": "Der IBAN der EEG wurde noch nicht konfiguriert",
-  "E_NO_CREDITOR_ID": "Die CREATOR_ID der EEG wurde noch nicht konfiguriert"
+  "E_BIC_MISSING": "Die BIC der EEG wurde noch nicht konfiguriert.",
+  "E_IBAN_MISSING": "Die IBAN der EEG wurde noch nicht konfiguriert.",
+  "E_NO_CREDITOR_ID": "Die CREDITOR_ID der EEG wurde noch nicht konfiguriert."
 }

--- a/src/components/EegBillingConfigCard.component.tsx
+++ b/src/components/EegBillingConfigCard.component.tsx
@@ -149,7 +149,7 @@ const EegBillingConfigCardComponent: FC = () => {
                                                 control={control}
                                                 type="text" readonly={!isAdmin()}/>
                             <InputForm name={"termsTextInvoice"}
-                                                label="Rechnungen: Abschlusstext (zB für Bedingungen)"
+                                                label="Rechnungen: Abschlusstext (z. B. für Bedingungen)"
                                                 control={control}
                                                 type="text" readonly={!isAdmin()}/>
                             <InputForm name={"invoiceNumberPrefix"}
@@ -157,21 +157,21 @@ const EegBillingConfigCardComponent: FC = () => {
                                                 control={control}
                                                 type="text" readonly={!isAdmin()}/>
                             <InputForm name={"invoiceNumberStart"}
-                                                label="Startwert für Rechnungsnummer"
+                                                label="Startwert für Rechnungsnummern"
                                                 control={control}
                                                 rules={{min: 0}}
                                                 type="number" readonly={!isAdmin()}/>
 
                             <InputForm name={"beforeItemsTextCreditNote"}
-                                                label="Gutschriften: Text vor Positionen"
+                                                label="Gutschriften für Mitgliedstyp Privat: Text vor Positionen"
                                                 control={control}
                                                 type="text" readonly={!isAdmin()}/>
                             <InputForm name={"afterItemsTextCreditNote"}
-                                                label="Gutschriften: Text nach Positionen"
+                                                label="Gutschriften für Mitgliedstyp Privat: Text nach Positionen"
                                                 control={control}
                                                 type="text" readonly={!isAdmin()}/>
                             <InputForm name={"termsTextCreditNote"}
-                                                label="Gutschriften: Abschlusstext"
+                                                label="Gutschriften für Mitgliedstyp Privat: Abschlusstext"
                                                 control={control}
                                                 type="text" readonly={!isAdmin()}/>
                             <InputForm name={"creditNoteNumberPrefix"}
@@ -185,15 +185,15 @@ const EegBillingConfigCardComponent: FC = () => {
                                                 type="number" readonly={!isAdmin()}/>
 
                             <InputForm name={"beforeItemsTextInfo"}
-                                                label="Gutschriften für Firmen: Text vor Positionen"
+                                                label="Gutschriften für Mitgliedstyp Firma: Text vor Positionen"
                                                 control={control}
                                                 type="text" readonly={!isAdmin()}/>
                             <InputForm name={"afterItemsTextInfo"}
-                                                label="Gutschriften für Firmen: Text nach Positionen"
+                                                label="Gutschriften für Mitgliedstyp Firma: Text nach Positionen"
                                                 control={control}
                                                 type="text" readonly={!isAdmin()}/>
                             <InputForm name={"termsTextInfo"}
-                                                label="Gutschriften für Firmen: Abschlusstext"
+                                                label="Gutschriften für Mitgliedstyp Firma: Abschlusstext"
                                                 control={control}
                                                 type="text" readonly={!isAdmin()}/>
 
@@ -203,7 +203,7 @@ const EegBillingConfigCardComponent: FC = () => {
                                                 type="text" readonly={!isAdmin()}/>
 
                             <InputForm name={"documentNumberSequenceLength"}
-                                                label="Dokumentennummer: Anzahl Stellen (wird mit führenden Nulle aufgefüllt)"
+                                                label="Dokumentennummer: Anzahl Stellen (wird mit führenden Nullen aufgefüllt)"
                                                 rules={{min: 1, max: 6}}
                                                 control={control}
                                                 type="number" readonly={!isAdmin()}/>

--- a/src/components/RateDetailPane.component.tsx
+++ b/src/components/RateDetailPane.component.tsx
@@ -65,7 +65,7 @@ const RateDetailPaneComponent: FC<RateDetailPaneComponentProps> = ({onSubmit, su
               })
             } else {
               showToast({
-                message: 'Tarif konnte nicht gelöscht werden. Bitte kontaktieren Sie ihren Administrator. Grund: ' + e.message,
+                message: 'Tarif konnte nicht gelöscht werden. Bitte kontaktieren Sie Ihren Administrator. Grund: ' + e.message,
                 duration: 4500,
                 color: "danger"
               })

--- a/src/components/core/elements/MeteringPointOffline.element.tsx
+++ b/src/components/core/elements/MeteringPointOffline.element.tsx
@@ -56,7 +56,7 @@ const MeteringPointOfflineElement: FC<{m: Metering}> = ({m}) => {
         (<div>
           <IonItem lines="none">
             <IonInput labelPlacement="floating"
-                      label="Aktivierungs Code"
+                      label="Aktivierungs-Code"
                       onIonChange={(e) => onActivationCodeChanged(e.target.value as string)}
                       counter={true} maxlength={35}></IonInput>
           </IonItem>

--- a/src/components/core/forms/MeterAddressForm/MeterAddressForm.element.tsx
+++ b/src/components/core/forms/MeterAddressForm/MeterAddressForm.element.tsx
@@ -97,11 +97,11 @@ const MeterAddressFormElement: FC<MeterAddressFormElementProps> = ({
       <InputForm name={"city"} label={t("address.city")} control={control} rules={{required: t("warnings.city_missing")}} type="text"
                  error={errors?.city} disabled={disableAddressFields} onChangePartial={_onChange}/>
       {showActivationMode &&
-      <CheckboxComponent label="Offline Registrierung" setChecked={onSetOffline}
+      <CheckboxComponent label="Offline-Registrierung" setChecked={onSetOffline}
                          checked={offline === 'OFFLINE'} style={{paddingTop: "0px"}}></CheckboxComponent>
       }
       { showActivationMode && offline === 'OFFLINE' &&
-          <InputForm name={"activationCode"} label="Activierungs-Code" control={control} rules={{required: "ActivierungsCode erforderlich"}} type="text"
+          <InputForm name={"activationCode"} label="Aktivierungs-Code" control={control} rules={{required: "Aktivierungs-Code erforderlich"}} type="text"
                      counter={true} maxlength={35} error={errors?.activationCode} onChangePartial={_onChange}/>
       }
       {isAdmin() && !isOnline &&

--- a/src/components/dashboard/EnergyOverview.component.tsx
+++ b/src/components/dashboard/EnergyOverview.component.tsx
@@ -137,7 +137,7 @@ const EnergyOverviewComponent: FC<OverviewComponentProps> = ({consumed, produced
                 <div>Produziert</div>
                 <IonIcon id="hover-help-producer" icon={helpCircleOutline} />
                 <IonPopover trigger="hover-help-producer" triggerAction="hover">
-                  <IonContent class="ion-padding">Production in der selektierten Periode. Der Balken visualisiert das Verhältnis von "Verteilung in der EEG / Gesamtproduktion"</IonContent>
+                  <IonContent class="ion-padding">Produktion in der selektierten Periode. Der Balken visualisiert das Verhältnis von "Verteilung in der EEG / Gesamtproduktion"</IonContent>
                 </IonPopover>
               </div>
             </div>

--- a/src/components/eegregistration/AddressEegProperties.component.tsx
+++ b/src/components/eegregistration/AddressEegProperties.component.tsx
@@ -19,7 +19,7 @@ const AddressEegPropertiesComponent: FC<AddressEegPropertiesComponentProps> = ({
       <InputForm name={"address.city"} label="Ort" control={control} rules={{required: "Ort fehlt"}} type="text" error={errors?.address?.city}/>
       <InputForm name={"address.zip"} label="Postleitzahl" control={control} rules={{required: "Postleitzahl fehlt"}} type="text" error={errors?.address?.zip}/>
       <InputForm name={"contact.phone"} label="Telefonnummer" control={control} type="text"/>
-      <InputForm name={"contact.email"} label="email" control={control} type="text"/>
+      <InputForm name={"contact.email"} label="E-Mail" control={control} type="text"/>
       <InputForm name={"optionals.website"} label="Webseite" control={control} type="text"/>
     </div>
   )

--- a/src/components/eegregistration/BusinessEegProperties.component.tsx
+++ b/src/components/eegregistration/BusinessEegProperties.component.tsx
@@ -21,7 +21,7 @@ const BusinessEegPropertiesComponent: FC<BusinessEegPropertiesComponentProps> = 
     {/*<CorePageTemplate>*/}
       <h2>Geschäftliches</h2>
       <InputForm name={"businessNr"} label="Geschäftsnummer" control={control} type="text" placeholder="Geschäftsnummer deiner EEG"/>
-      <InputForm name={"taxNumber"} label="Streuernummer" control={control} type="text"/>
+      <InputForm name={"taxNumber"} label="Steuernummer" control={control} type="text"/>
       <InputForm name={"vatNumber"} label="Mehrwertsteuer-ID" control={control} type="text"/>
 
       <h6>Verrechnung</h6>
@@ -33,7 +33,7 @@ const BusinessEegPropertiesComponent: FC<BusinessEegPropertiesComponentProps> = 
         {key: "ANNUAL", value: "Jährlich"},
       ]}></SelectForm>
       <IbanInputForm name={"accountInfo.iban"} control={control} />
-      <InputForm name={"accountInfo.owner"} label="Konto Inhaber" control={control} type="text"/>
+      <InputForm name={"accountInfo.owner"} label="Kontoinhaber" control={control} type="text"/>
       <IonItem lines="none">
         <Controller
           name={"accountInfo.sepa"}

--- a/src/components/participantPane/ParticipantDetailsPane.component.tsx
+++ b/src/components/participantPane/ParticipantDetailsPane.component.tsx
@@ -234,7 +234,7 @@ const ParticipantDetailsPaneComponent: FC = () => {
   const archive = (sp: EegParticipant) => {
     participantAlert({
       subHeader: "Mitglied archivieren",
-      message: "Das Mitglied ist nach dem ARCHIVIERUNG'S Prozess in deiner Übersicht nicht mehr verhanden.",
+      message: "Das Mitglied ist nach dem Archivierungsprozess in deiner Übersicht nicht mehr vorhanden.",
       buttons: [
         {
           text: 'Cancel',
@@ -251,7 +251,7 @@ const ParticipantDetailsPaneComponent: FC = () => {
             .unwrap()
             .catch(() => {
               toaster({
-                message: 'Mitglied konnte nicht gelöscht werden. Bitte kontaktieren Sie ihren Administrator.',
+                message: 'Mitglied konnte nicht gelöscht werden. Bitte kontaktieren Sie Ihren Administrator.',
                 duration: 4500,
                 color: "danger"
               })

--- a/src/components/participantPane/ParticipantPane.component.tsx
+++ b/src/components/participantPane/ParticipantPane.component.tsx
@@ -475,7 +475,7 @@ const ParticipantPaneComponent: FC = () => {
           presentAlert({
             subHeader: "Fehler bei der Vorschauerstellung",
             message:
-              "Bei der Erstellung der Vorschau ist ein Fehler aufgetreten. Bitte prüfen Sie die Stammdaten und achten Sie vor allem darauf, bei allen Nutzern & Zählpunkten einen Tarif zu setzen. Wiederholen Sie den Vorgang, wenn allen Daten korrigiert wurden.",
+              "Bei der Erstellung der Vorschau ist ein Fehler aufgetreten. Bitte prüfen Sie die Stammdaten und achten Sie vor allem darauf, bei allen Nutzern & Zählpunkten einen Tarif zu setzen. Wiederholen Sie den Vorgang, wenn alle Daten korrigiert wurden.",
             buttons: ["OK"],
           });
         } else {

--- a/src/components/processDetails/ProcessRegisterMeter.component.tsx
+++ b/src/components/processDetails/ProcessRegisterMeter.component.tsx
@@ -132,7 +132,7 @@ const ProcessRegisterMeterComponent: FC<ProcessRegisterMeterComponentProps> = ({
                                     }
                                   })} label={t("metering")} rules={{required: true}}/>
 
-            <CheckboxComponent label={"Offline Registrierung"} checked={offline} setChecked={setOffline}></CheckboxComponent>
+            <CheckboxComponent label={"Offline-Registrierung"} checked={offline} setChecked={setOffline}></CheckboxComponent>
             { offline && 
               <InputForm name="activationCode" control={control} label={"Aktivierungs-Code"} counter={true} maxlength={35}/>
             }

--- a/src/util/Notificaton.util.tsx
+++ b/src/util/Notificaton.util.tsx
@@ -13,21 +13,18 @@ export function buildNotificationText(type: string, process: string, notificatio
               erfolgreich bestätigt.</u></strong></p>
           )
         case 'ANFORDERUNG_ECON':
-          return <p>Die Zählpunkte <strong>{n.message.meteringPoint}</strong> wurden für die <strong><u>Online
-            Registrierung</u></strong> angefordert.</p>
+          return <p>Die Zählpunkte <strong>{n.message.meteringPoint}</strong> wurden für die <strong><u>Online-Registrierung</u></strong> angefordert.</p>
         case 'ANFORDERUNG_PT':
           return <p>Für die Zählpunkte <strong>{n.message.meteringPoint}</strong> wurden <strong><u>Energiedaten
             angefordert.</u></strong></p>
         case 'ANTWORT_ECON':
-          return <p>Für die Zählpunkte <strong>{n.message.meteringPoint}</strong> wurde die <strong><u>Online
-            Registrierung</u></strong> gestartet.</p>
+          return <p>Für die Zählpunkte <strong>{n.message.meteringPoint}</strong> wurde die <strong><u>Online-Registrierung</u></strong> gestartet.</p>
         case 'ANTWORT_PT':
           return <p>Die <strong><u>ENERGIEDATENANFRAGE</u></strong> für die
             Zählpunkte <strong>{n.message.meteringPoint}</strong> wurde
             angenommen.</p>
         case 'ABLEHNUNG_ECON':
-          return <p>Für die Zählpunkte <strong>{n.message.meteringPoint}</strong> wurde die <strong><u>Online
-            Registrierung</u></strong> abgelehnt. ({n.message.responseCode})</p>
+          return <p>Für die Zählpunkte <strong>{n.message.meteringPoint}</strong> wurde die <strong><u>Online-Registrierung</u></strong> abgelehnt. ({n.message.responseCode})</p>
         case 'ABSCHLUSS_ECON':
           return <p>Die Zählpunkte <strong>{n.message.meteringPoint}</strong> wurden vom Netzbetreiber in <strong><u>deine
             EEG aufgenommen.</u></strong></p>


### PR DESCRIPTION
## 1. Billing-Config: Gutschriftentext-Felder nach Mitgliedstyp benannt
Damit klar ist, von welchem Wert die Zuordnung abhängt (die Tarifmodelle bekommen dieselbe Firma/Privat-Ausprägung):
- „Gutschriften: …" → **„Gutschriften für Mitgliedstyp Privat: …"** (Erzeuger ohne UID)
- „Gutschriften für Firmen: …" → **„Gutschriften für Mitgliedstyp Firma: …"** (UID, Reverse-Charge)

Plus Tippfehler in der Karte: „führenden **Nullen**", „**z. B.**", „**Rechnungsnummern**".

## 2. Deutscher Rechtschreib-Sweep (Fable-Audit)
Korrekturen an `locales/de/common.json`, `error.json` und mehreren Komponenten — **nur Text, keine Logik**:
- **Echte Tippfehler:** Streuernummer→Steuernummer, Peroide→Periode, verhanden→vorhanden, Activierungs-Code→Aktivierungs-Code, Production→Produktion, ARCHIVIERUNG'S→Archivierungsprozess.
- **Flexion/Grammatik:** Mitgliedbeitrag→Mitgliedsbeitrag, Mandatreferenz→Mandatsreferenz, „des Teilnahmefaktor**s**", „mit den Marktpartner**n**", „wenn **alle** Daten", Höflichkeits-„**Ihren**".
- **Komposita/Durchkopplung:** Zählpunktgebühr, Kontaktperson, Kontoinhaber, Filteroptionen, Netzbetreiber-ID, Gemeinschafts-ID, Online-/Offline-Registrierung, E-Mail-Adresse, USt., SEPA.

Bewusst **nicht** enthalten (Stil/Semantik, laut Absprache): „Prozess History"→Prozesshistorie, „runtergeladen"→heruntergeladen, „Nummern"→Ziffern u. Ä. Nebenbefund (nicht angefasst): Code-/Datei-Tippfehler wie `Dashbaord.page.tsx`, `Notificaton.util.tsx`, `selectedPeroid` — das wäre Refactoring, kein Text-Fix.

## Verifikation
`tsc --noEmit` grün; beide Locale-JSONs valide; i18n-Interpolationen (`$t(...)`, `{{...}}`) unangetastet. 14 Dateien, reine Textänderungen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)