### PR TITLE
feat(mail): Mitglieds-E-Mail validieren+normalisieren, Mail-Fehler-Notifications lesbar, Ungültig-Badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ this changelog highlights the changes relevant for overview and operations.
 
 ## [Unreleased]
 
+### Added
+- Member e-mail hardening (web side of the suite-wide mail-address hardening; prod log
+  review found 73 failed sends across 11 tenants in one week):
+  - The **registration** form now validates the e-mail format — it only had a
+    required-check, so `'x'` or a bare space were accepted; the edit form already
+    validated. Both forms now use one shared rule (`src/util/EmailAddress.util.ts`:
+    ASCII local part, TLD >= 2 letters, `;`-separated lists without spaces).
+  - The participant service normalizes the address on **create, update and partial
+    update** (trim per `;`-part, canonical `;`-join) before sending — the backend
+    enforces the same rule server-side.
+  - Member detail pane shows an **"E-Mail ungültig"** chip when the stored address
+    does not match the rule (legacy data), so admins can spot and fix it.
+  - Notifications: failed mail sends (`Mail` log notifications from the backend) now
+    render with a readable text — previously the error row appeared with an icon but
+    an **empty** message line; Excel-import notifications now list their hint messages
+    (e.g. rows whose e-mail was not imported).
+
+### Fixed
+- EEG master data: the e-mail field's validation rule used `regex:` — not a
+  react-hook-form rule key — so it never ran; now a working `pattern` with the shared rule.
+
 ### Changed
 - CI: Preview-Deployments (ADR-0007) — Push auf `preview/**` baut+deployt on-demand in die Dev-Zone (sha-pinned, kein `:latest`), Auto-Reset bei Branch-Delete.
 - Billing config: removed the "Erzeuge Gutschriften für UST-pflichtige Erzeuger" toggle.

--- a/src/__test__/utils/EmailAddress.util.test.ts
+++ b/src/__test__/utils/EmailAddress.util.test.ts
@@ -1,0 +1,45 @@
+import {describe, expect, it} from "vitest";
+import {EMAIL_LIST_PATTERN, isValidEmailList, normalizeEmailList} from "../../util/EmailAddress.util";
+
+describe("normalizeEmailList", () => {
+  it("trims outer whitespace per ';'-part and joins without spaces", () => {
+    expect(normalizeEmailList(" a@x.at ")).toBe("a@x.at");
+    expect(normalizeEmailList("a@x.at ; b@y.at")).toBe("a@x.at;b@y.at");
+    expect(normalizeEmailList(" a@x.at ")).toBe("a@x.at"); // NBSP
+    expect(normalizeEmailList("a@x.at;;b@y.at")).toBe("a@x.at;b@y.at");
+    expect(normalizeEmailList("  ")).toBe("");
+    expect(normalizeEmailList(undefined)).toBe("");
+    expect(normalizeEmailList(null)).toBe("");
+  });
+});
+
+describe("isValidEmailList", () => {
+  it("accepts valid lists (after normalization) and empty values", () => {
+    expect(isValidEmailList("a@x.at")).toBe(true);
+    expect(isValidEmailList(" a@x.at ")).toBe(true);
+    expect(isValidEmailList("A@X.AT")).toBe(true);
+    expect(isValidEmailList("a@eeg.energy")).toBe(true); // modern gTLD
+    expect(isValidEmailList("a@x.at; b@y.at")).toBe(true);
+    expect(isValidEmailList("")).toBe(true); // no address is not an error
+    expect(isValidEmailList("  ")).toBe(true);
+    expect(isValidEmailList(undefined)).toBe(true);
+  });
+
+  it("rejects garbage, non-ASCII local parts and inner whitespace", () => {
+    expect(isValidEmailList("x")).toBe(false);
+    expect(isValidEmailList("hedwig.schön@x.at")).toBe(false);
+    expect(isValidEmailList("a b@x.at")).toBe(false);
+    expect(isValidEmailList("a@x")).toBe(false);
+    expect(isValidEmailList("a@x.at;x")).toBe(false); // one bad part rejects the list
+  });
+});
+
+describe("EMAIL_LIST_PATTERN (react-hook-form rule)", () => {
+  it("matches the canonical stored format only", () => {
+    expect(EMAIL_LIST_PATTERN.test("a@x.at")).toBe(true);
+    expect(EMAIL_LIST_PATTERN.test("a@x.at;b@y.at")).toBe(true);
+    expect(EMAIL_LIST_PATTERN.test("a@eeg.energy")).toBe(true);
+    expect(EMAIL_LIST_PATTERN.test("x")).toBe(false);
+    expect(EMAIL_LIST_PATTERN.test("a@x.at; b@y.at")).toBe(false); // no spaces in canonical form
+  });
+});

--- a/src/components/ParticipantRegisterCommonPane.component.tsx
+++ b/src/components/ParticipantRegisterCommonPane.component.tsx
@@ -13,6 +13,7 @@ import DatePickerFormElement from "./form/DatePickerForm.element";
 import DatePickerCoreElement from "./core/elements/DatePickerCore.element";
 import SelectForm from "./form/SelectForm.component";
 import {DebitExtensionComponent} from "./core/DebitExtensionComponent";
+import {EMAIL_LIST_PATTERN} from "../util/EmailAddress.util";
 
 interface ParticipantRegisterCommonPaneComponentProps {
   participant: EegParticipant;
@@ -92,7 +93,13 @@ const ParticipantRegisterCommonPaneComponent: FC<ParticipantRegisterCommonPaneCo
                        type="text" error={errors.billingAddress?.city}/>
             <InputForm name={"contact.phone"} label={t("phone")} control={control} type="text"/>
             <InputForm name={"contact.email"} label={t("email")} control={control} type="text"
-                       rules={{required: t("warnings.email_missing")}} error={errors.contact?.email}/>
+                       rules={{
+                         required: t("warnings.email_missing"),
+                         pattern: {
+                           value: EMAIL_LIST_PATTERN,
+                           message: t("warnings.email", {context: "wrong"})
+                         }
+                       }} isEmail={true} multiple={true} error={errors.contact?.email}/>
           </IonList>
 
         </div>

--- a/src/components/ParticipantRegisterCommonPane.component.tsx
+++ b/src/components/ParticipantRegisterCommonPane.component.tsx
@@ -13,7 +13,7 @@ import DatePickerFormElement from "./form/DatePickerForm.element";
 import DatePickerCoreElement from "./core/elements/DatePickerCore.element";
 import SelectForm from "./form/SelectForm.component";
 import {DebitExtensionComponent} from "./core/DebitExtensionComponent";
-import {EMAIL_LIST_PATTERN} from "../util/EmailAddress.util";
+import {isValidEmailList} from "../util/EmailAddress.util";
 
 interface ParticipantRegisterCommonPaneComponentProps {
   participant: EegParticipant;
@@ -95,10 +95,10 @@ const ParticipantRegisterCommonPaneComponent: FC<ParticipantRegisterCommonPaneCo
             <InputForm name={"contact.email"} label={t("email")} control={control} type="text"
                        rules={{
                          required: t("warnings.email_missing"),
-                         pattern: {
-                           value: EMAIL_LIST_PATTERN,
-                           message: t("warnings.email", {context: "wrong"})
-                         }
+                         // validate on the normalized form (not a raw pattern):
+                         // healable input like a leading space stays valid — the
+                         // service normalizes it on save
+                         validate: (v: string | undefined) => isValidEmailList(v) || t("warnings.email", {context: "wrong"})
                        }} isEmail={true} multiple={true} error={errors.contact?.email}/>
           </IonList>
 

--- a/src/components/core/MemberForm.component.tsx
+++ b/src/components/core/MemberForm.component.tsx
@@ -19,6 +19,7 @@ import {DebitExtensionComponent} from "./DebitExtensionComponent";
 import DatePickerInput from "../form/NewDatePickerForm.component";
 import {Moment} from "moment";
 import {LocalDate} from "local-date";
+import {EMAIL_LIST_PATTERN} from "../../util/EmailAddress.util";
 
 interface MemberFormComponentProps {
   participant: EegParticipant
@@ -147,7 +148,7 @@ const MemberFormComponent: FC<MemberFormComponentProps> = ({participant, rates, 
           <InputForm name={"contact.email"} label={t("email")} control={control} rules={{
             required: t("warnings.email", {context: "missing"}),
             pattern: {
-              value: /^(?:[A-Z0-9\._%\+-]+@[A-Z0-9-]+\.[A-Z\.]{2,})(?:;[A-Z0-9\._%\+-]+@[A-Z0-9-]+\.[A-Z\.]{2,}){0,}$/i,
+              value: EMAIL_LIST_PATTERN,
               message: t("warnings.email", {context: "wrong"})}
           }} isEmail={true} multiple={true} error={errors.contact?.email} onChangePartial={onUpdateBaseData}/>
           <InputForm name={"vatNumber"} label={t("uid")}control={control} type="text" onChangePartial={onUpdateBaseData}/>

--- a/src/components/core/MemberForm.component.tsx
+++ b/src/components/core/MemberForm.component.tsx
@@ -19,7 +19,7 @@ import {DebitExtensionComponent} from "./DebitExtensionComponent";
 import DatePickerInput from "../form/NewDatePickerForm.component";
 import {Moment} from "moment";
 import {LocalDate} from "local-date";
-import {EMAIL_LIST_PATTERN} from "../../util/EmailAddress.util";
+import {isValidEmailList} from "../../util/EmailAddress.util";
 
 interface MemberFormComponentProps {
   participant: EegParticipant
@@ -147,9 +147,10 @@ const MemberFormComponent: FC<MemberFormComponentProps> = ({participant, rates, 
           <PhoneInputForm name={"contact.phone"} control={control} setValue={setValue} onChangePartial={onUpdateBaseData} error={errors.contact?.phone}/>
           <InputForm name={"contact.email"} label={t("email")} control={control} rules={{
             required: t("warnings.email", {context: "missing"}),
-            pattern: {
-              value: EMAIL_LIST_PATTERN,
-              message: t("warnings.email", {context: "wrong"})}
+            // validate on the normalized form — healable input (outer
+            // whitespace, "; " between parts) stays valid and is
+            // normalized by the service on save
+            validate: (v: string | undefined) => isValidEmailList(v) || t("warnings.email", {context: "wrong"})
           }} isEmail={true} multiple={true} error={errors.contact?.email} onChangePartial={onUpdateBaseData}/>
           <InputForm name={"vatNumber"} label={t("uid")}control={control} type="text" onChangePartial={onUpdateBaseData}/>
         </IonList>

--- a/src/components/participantPane/ParticipantDetailsPane.component.tsx
+++ b/src/components/participantPane/ParticipantDetailsPane.component.tsx
@@ -4,7 +4,7 @@ import cn from "classnames";
 
 import "./ParticipantDetailsPane.compoenent.css"
 import {
-  IonButton, IonButtons, IonCard,
+  IonButton, IonButtons, IonCard, IonChip,
   IonIcon,
   IonItem,
   IonLabel,
@@ -31,6 +31,7 @@ import {
   updateParticipant, updateParticipantPartial
 } from "../../store/participant";
 import {formatMeteringPointString} from "../../util/Helper.util";
+import {isValidEmailList} from "../../util/EmailAddress.util";
 import AllowParticipantDialog from "../dialogs/AllowParticipant.dialog";
 import {OverlayEventDetail} from "@ionic/react/dist/types/components/react-component-lib/interfaces";
 import InvoiceDocumentComponent from "./InvoiceDocument.component";
@@ -302,6 +303,9 @@ const ParticipantDetailsPaneComponent: FC = () => {
       <div className={"details-body"} style={{display: "flex", flexDirection: "column", height: "100%"}}>
         <div className={"details-header"}>
           <div><h4>{selectedParticipant.firstname} {selectedParticipant.lastname}</h4></div>
+          {!isValidEmailList(selectedParticipant.contact?.email) &&
+            <IonChip color="danger">E-Mail ungültig</IonChip>
+          }
           {/*<div style={{minWidth: "240px"}}>*/}
           {/*  <IonItem button lines="none" style={{fontSize: "12px", marginRight: "60px"}}*/}
           {/*           className={"participant-header"}*/}

--- a/src/models/eeg.model.ts
+++ b/src/models/eeg.model.ts
@@ -222,6 +222,16 @@ export class Message {
 
     return value as string
   }
+
+  /**
+   * Log-style notifications (mail errors, Excel import) carry a
+   * `messages` array built from the backend's LogMessage
+   * (`{kind, metering_point, message_code, message}`).
+   */
+  public get logMessages(): { kind: string; metering_point: string; message_code: string; message: string }[] {
+    const value = this.properties ? this.properties["messages"] : undefined
+    return Array.isArray(value) ? value : []
+  }
 }
 
 export interface EegNotification {

--- a/src/pages/Eeg.page.tsx
+++ b/src/pages/Eeg.page.tsx
@@ -22,6 +22,7 @@ import {AccountInfo, Address, Contact, Eeg, Optionals} from "../models/eeg.model
 import {IbanInputForm} from "../components/form/IbanInputForm";
 import {PhoneInputForm} from "../components/form/PhoneInputForm";
 import {useLocale} from "../store/hook/useLocale";
+import {EMAIL_LIST_PATTERN} from "../util/EmailAddress.util";
 
 
 const EMPTY_EEG_ENTITY = {
@@ -228,7 +229,14 @@ const EegPage: FC = () => {
                   <PhoneInputForm name={"contact.phone"} control={control} readonly={!isAdmin()} setValue={setValue}
                                   onChangePartial={onChangeField("phone")}/>
                   <InputFormComponent name={"contact.email"} label={t("email")} control={control}
-                                      rules={{regex: /[a-z\.]@[a-z]\.\w{3}/}} type="text" readonly={!isAdmin()}
+                                      rules={{
+                                        // was `regex:` — not a react-hook-form rule key, the
+                                        // old check never ran
+                                        pattern: {
+                                          value: EMAIL_LIST_PATTERN,
+                                          message: t("warnings.email", {context: "wrong"})
+                                        }
+                                      }} type="text" readonly={!isAdmin()}
                                       error={errors.contact?.email}
                                       onChangePartial={onChangeField("email")}/>
                 </IonCard>

--- a/src/pages/Eeg.page.tsx
+++ b/src/pages/Eeg.page.tsx
@@ -22,7 +22,7 @@ import {AccountInfo, Address, Contact, Eeg, Optionals} from "../models/eeg.model
 import {IbanInputForm} from "../components/form/IbanInputForm";
 import {PhoneInputForm} from "../components/form/PhoneInputForm";
 import {useLocale} from "../store/hook/useLocale";
-import {EMAIL_LIST_PATTERN} from "../util/EmailAddress.util";
+import {isValidEmailList} from "../util/EmailAddress.util";
 
 
 const EMPTY_EEG_ENTITY = {
@@ -231,11 +231,10 @@ const EegPage: FC = () => {
                   <InputFormComponent name={"contact.email"} label={t("email")} control={control}
                                       rules={{
                                         // was `regex:` — not a react-hook-form rule key, the
-                                        // old check never ran
-                                        pattern: {
-                                          value: EMAIL_LIST_PATTERN,
-                                          message: t("warnings.email", {context: "wrong"})
-                                        }
+                                        // old check never ran. validate on the normalized
+                                        // form so healable input (outer whitespace) is not
+                                        // rejected — backend normalizes on save.
+                                        validate: (v: string | undefined) => isValidEmailList(v) || t("warnings.email", {context: "wrong"})
                                       }} type="text" readonly={!isAdmin()}
                                       error={errors.contact?.email}
                                       onChangePartial={onChangeField("email")}/>

--- a/src/service/participant.service.ts
+++ b/src/service/participant.service.ts
@@ -4,6 +4,14 @@ import {EegParticipant} from "../models/members.model";
 import {AuthService} from "./auth.service";
 import {SelectedPeriod} from "../models/energy.model";
 import {Metering} from "../models/meteringpoint.model";
+import {normalizeEmailList} from "../util/EmailAddress.util";
+
+// Canonical e-mail format on every write: trim each ';'-part, no
+// spaces. The backend enforces the same rule server-side.
+const withNormalizedEmail = (participant: EegParticipant): EegParticipant =>
+  participant.contact?.email !== undefined
+    ? {...participant, contact: {...participant.contact, email: normalizeEmailList(participant.contact.email)}}
+    : participant
 
 export class ParticipantService extends BaseService {
   public constructor(authService: AuthService) {
@@ -23,6 +31,9 @@ export class ParticipantService extends BaseService {
 
   async updateParticipantPartial(tenant: string, id: string, value: { path: string, value: any }): Promise<EegParticipant> {
     const token = await this.lookupToken()
+    if (value.path === "contact.email" && typeof value.value === "string") {
+      value = {...value, value: normalizeEmailList(value.value)}
+    }
     return fetch(`${API_API_SERVER}/participant/v2/${id}`, {
       method: 'PUT',
       headers: {
@@ -60,7 +71,7 @@ export class ParticipantService extends BaseService {
         ...this.getSecureHeaders(token, tenant),
         'Content-Type': 'application/json'
       },
-      body: JSON.stringify(participant)
+      body: JSON.stringify(withNormalizedEmail(participant))
     }).then(this.handleErrors).then(res => res.json());
   }
 
@@ -72,7 +83,7 @@ export class ParticipantService extends BaseService {
         ...this.getSecureHeaders(token, tenant),
         'Content-Type': 'application/json'
       },
-      body: JSON.stringify(participant)
+      body: JSON.stringify(withNormalizedEmail(participant))
     }).then(this.handleErrors).then(res => res.json());
   }
 

--- a/src/util/EmailAddress.util.ts
+++ b/src/util/EmailAddress.util.ts
@@ -1,0 +1,30 @@
+/**
+ * Shared e-mail address rule of the eegfaktura suite (backend, eda-xp,
+ * billing, web): per ';'-separated part — outer whitespace trimmed
+ * (JS trim() covers NBSP), ASCII local part, TLD of at least two
+ * letters, no TLD allowlist. Canonical storage format: parts joined
+ * with ';' and no spaces.
+ */
+export const EMAIL_PART_PATTERN = /^[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}$/i
+
+/** react-hook-form pattern for a ';'-separated address list (no spaces). */
+export const EMAIL_LIST_PATTERN =
+  /^[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}(?:;[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,})*$/i
+
+/** Trim each ';'-part, drop empties, re-join with ';' (no spaces). */
+export const normalizeEmailList = (raw?: string | null): string =>
+  (raw ?? "")
+    .split(";")
+    .map(p => p.trim())
+    .filter(p => p.length > 0)
+    .join(";")
+
+/**
+ * True when the (normalized) list is well-formed. An empty value is
+ * valid — a member without an e-mail address is not an error.
+ */
+export const isValidEmailList = (raw?: string | null): boolean => {
+  const normalized = normalizeEmailList(raw)
+  if (normalized === "") return true
+  return normalized.split(";").every(p => EMAIL_PART_PATTERN.test(p))
+}

--- a/src/util/Notificaton.util.tsx
+++ b/src/util/Notificaton.util.tsx
@@ -53,11 +53,25 @@ export function buildNotificationText(type: string, process: string, notificatio
           return <p>Für die Zählpunkte <strong>{n.message.meteringPoint}</strong> wurden <strong><u>die Änderungen des
             Teilnahmefaktors
             angenommen.</u></strong></p>
+        case 'Mail':
+          // Fehlgeschlagener Mailversand (z. B. ungültige Empfänger-Adresse) —
+          // ohne diesen Zweig erschien die Notification als leere Zeile.
+          return <p><strong><u>Mailversand fehlgeschlagen:</u></strong> {
+            (n.message.logMessages ?? []).map(m => `${m.metering_point} — ${m.message}`).join("; ")
+          }</p>
       }
       break
     }
-    case "EXCEL_IMPORT":
+    case "EXCEL_IMPORT": {
+      const n = notification as EegNotification
+      const hints = n.message?.logMessages ?? []
+      if (hints.length > 0) {
+        return (<p>Excel Stammdaten importiert — <strong>Hinweise:</strong> {
+          hints.map(m => `${m.metering_point}: ${m.message}`).join("; ")
+        }</p>)
+      }
       return (<p>Excel Stammdaten importiert </p>)
+    }
   }
   return ""
 }


### PR DESCRIPTION
## Was

web-Teil der suite-weiten **Mailversand-Adress-Härtung** (Konzept `konzept-mailversand-adress-haertung.md`).

- **Gemeinsame Regel** in `src/util/EmailAddress.util.ts` (ASCII-Local-Part, TLD ≥ 2 Buchstaben, `;`-Listen kanonisch ohne Spaces) + Vitest-Tests.
- **Registrierungs-Formular validiert endlich die E-Mail** — bisher nur `required`, `'x'` oder ein Leerzeichen waren speicherbar (eine der realen Müllquellen aus dem Prod-Log-Befund). Edit-Formular auf dieselbe Regel umgestellt.
- **Validierung auf der normalisierten Form** (`validate` statt rohem `pattern`, Review-Finding #5): heilbare Eingaben (führendes Leerzeichen, `"; "`) bleiben gültig — Formular = Badge = Service = Backend; kein stiller Form-Reset beim Blur.
- **Service normalisiert** bei Create/Update/Partial-Update (Trim je `;`-Teil, kanonischer Join) — das Backend erzwingt dieselbe Regel serverseitig.
- **EEG-Stammdaten**: Die E-Mail-Regel nutzte `regex:` — kein gültiger react-hook-form-Key, lief also **nie**; jetzt funktionierendes `validate`.
- **Notifications**: `Mail`-Fehler-Notifications rendern jetzt lesbaren Text (bisher Icon + **leere Zeile**); Excel-Import-Notifications listen ihre Hinweise (z. B. nicht übernommene E-Mails).
- **Badge „E-Mail ungültig"** im Mitglieder-Detail für Altdaten, die der Regel nicht entsprechen.

## Tests

`tsc --noEmit` ✅ · Unit-Suite 7 Files / 18 Tests ✅ (inkl. neuer Util-Tests mit echten NBSP-Bytes).

Gegenstücke: backend #25, eda-xp #15, billing #29 (gleicher Branchname).

🤖 Generated with [Claude Code](https://claude.com/claude-code)