### PR TITLE
Keep billing periods selectable for EEGs without energy data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ this changelog highlights the changes relevant for overview and operations.
 
 ## [Unreleased]
 
+### Fixed
+- Billing period selector: for an EEG **without energy data** (e.g. the platform-fee EEG
+  `RC000000`) the selectable periods no longer collapse to the current period. The period
+  range was derived solely from energy metadata, which degenerates to "today" without data,
+  so once a quarter ended its period could no longer be selected for billing. It now falls
+  back to the EEG creation date (`createdAt`, newly provided by the backend) as the lower
+  bound. EEGs **with** energy data are unaffected (range still comes from their metadata).
+
 ## [1.0.7] – 2026-07-05
 
 ### Added

--- a/src/components/participantPane/ParticipantPeriodHeader.component.tsx
+++ b/src/components/participantPane/ParticipantPeriodHeader.component.tsx
@@ -1,4 +1,4 @@
-import React, {FC} from "react";
+import React, {FC, useMemo} from "react";
 import {
   IonCheckbox,
   IonCol,
@@ -14,6 +14,7 @@ import {CheckboxChangeEventDetail} from "@ionic/core";
 import PeriodSelectorElement from "../core/PeriodSelector.element";
 import {useAppSelector} from "../../store";
 import {periodsSelector} from "../../store/energy";
+import {eegSelector} from "../../store/eeg";
 
 interface ParticipantPeriodHeaderComponentProps {
   activePeriod: SelectedPeriod | undefined;
@@ -21,8 +22,27 @@ interface ParticipantPeriodHeaderComponentProps {
   onUpdatePeriod: (selectedPeriod: SelectedPeriod) => void;
 }
 
+// ISO date ("YYYY-MM-DD") -> "DD.MM.YYYY" as expected by splitDate/yearMonth.
+const isoToDottedDate = (iso: string): string | undefined => {
+  const parts = iso.split(/[T\s]/)[0].split("-");
+  return parts.length === 3 ? `${parts[2]}.${parts[1]}.${parts[0]}` : undefined;
+};
+
 const ParticipantPeriodHeaderComponent: FC<ParticipantPeriodHeaderComponentProps> = ({activePeriod, selectAll, onUpdatePeriod}) => {
   const periods = useAppSelector(periodsSelector);
+  const eeg = useAppSelector(eegSelector);
+
+  // periodsSelector derives the selectable range from energy metadata only. For an EEG
+  // without any energy data (e.g. the platform-fee EEG) it degenerates to "today", which
+  // drops past periods once a period boundary is crossed. Fall back to the EEG creation
+  // date so past billing periods stay selectable; EEGs with energy data are unaffected.
+  const effectivePeriods = useMemo(() => {
+    if (periods.end === "" && eeg?.createdAt) {
+      const begin = isoToDottedDate(eeg.createdAt);
+      if (begin) return {begin, end: ""};
+    }
+    return periods;
+  }, [periods, eeg?.createdAt]);
 
   return (
     <div style={{marginLeft: "5px", margin: "0 5px 10px 5px", borderBottom: "2px solid gray"}}>
@@ -35,7 +55,7 @@ const ParticipantPeriodHeaderComponent: FC<ParticipantPeriodHeaderComponentProps
         </IonCol>
         <IonCol>
           <IonItem lines="none">
-          <PeriodSelectorElement activePeriod={activePeriod} periods={periods} onUpdatePeriod={onUpdatePeriod} />
+          <PeriodSelectorElement activePeriod={activePeriod} periods={effectivePeriods} onUpdatePeriod={onUpdatePeriod} />
           </IonItem>
         </IonCol>
       </IonRow>

--- a/src/models/eeg.model.ts
+++ b/src/models/eeg.model.ts
@@ -21,6 +21,7 @@ export interface Eeg {
   accountInfo: AccountInfo;
   optionals: Optionals;
   online: boolean;
+  createdAt?: string;
 }
 
 export interface EegOwner {


### PR DESCRIPTION
## Problem
For an EEG **without energy data** (e.g. the platform-fee EEG `RC000000`), the billing period dropdown only offers the current period. The selectable range comes from `periodsSelector`, which derives `{begin, end}` from energy metadata only; with no data it seeds `begin = today`, `end = ""`, so `generatePeriodOptions` produces nothing before today and only the current period (via the `unshift(currentPeriod)` fallback) remains. Consequence: once a quarter ends, it can no longer be selected for billing — reported from prod (Q2 of RC000000 not selectable after 1 July).

## Change
In `ParticipantPeriodHeaderComponent` (the billing/participant-pane period header), when there is **no** energy metadata (`periods.end === ""`), fall back to the EEG creation date `createdAt` (newly provided by the backend) as the lower bound. ISO `createdAt` is converted to the dotted `DD.MM.YYYY` form the period helpers expect.

- EEGs **with** energy data are unaffected — range still comes from their metadata.
- Scoped to the participant-pane header only; the shared `PeriodSelectorElement` and the energy chart navbars are untouched.

Depends on eegfaktura-backend#27 (adds `createdAt` to the EEG API).

## Verification
- `tsc --noEmit` clean.
- Unit tests: 18/18 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)