### PR TITLE
docs(changelog): release v1.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ this changelog highlights the changes relevant for overview and operations.
 
 ## [Unreleased]
 
+## [1.0.8] – 2026-07-05
+
 ### Fixed
 - Billing period selector: for an EEG **without energy data** (e.g. the platform-fee EEG
   `RC000000`) the selectable periods no longer collapse to the current period. The period


### PR DESCRIPTION
Stamp the billing-period fallback fix as release **v1.0.8** (image `ghcr.io/vfeeg-development/vfeeg-web:v1.0.8` already crane-tagged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)