### PR TITLE
Billing period selector spans up to the current period

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ this changelog highlights the changes relevant for overview and operations.
 
 ## [Unreleased]
 
+### Fixed
+- Billing period selector, follow-up to v1.0.8: the selectable range is no longer capped by
+  where energy data ends. Billing is time-driven, but the range came straight from the energy
+  metadata, so an EEG whose data is frozen in the past (e.g. the platform-fee EEG `RC000000`
+  with a single stale 2022 record) only offered that old period plus the current one — every
+  quarter in between (incl. the one being billed) was missing. The upper bound is now always
+  the current period; the lower bound stays the energy start, or the EEG creation date
+  (`createdAt`) when there is no energy data. EEGs with up-to-date energy data are unaffected.
+
 ## [1.0.8] – 2026-07-05
 
 ### Fixed

--- a/src/components/participantPane/ParticipantPeriodHeader.component.tsx
+++ b/src/components/participantPane/ParticipantPeriodHeader.component.tsx
@@ -28,20 +28,30 @@ const isoToDottedDate = (iso: string): string | undefined => {
   return parts.length === 3 ? `${parts[2]}.${parts[1]}.${parts[0]}` : undefined;
 };
 
+const todayDottedDate = (): string => {
+  const n = new Date();
+  return `${n.getDate()}.${n.getMonth() + 1}.${n.getFullYear()}`;
+};
+
 const ParticipantPeriodHeaderComponent: FC<ParticipantPeriodHeaderComponentProps> = ({activePeriod, selectAll, onUpdatePeriod}) => {
   const periods = useAppSelector(periodsSelector);
   const eeg = useAppSelector(eegSelector);
 
-  // periodsSelector derives the selectable range from energy metadata only. For an EEG
-  // without any energy data (e.g. the platform-fee EEG) it degenerates to "today", which
-  // drops past periods once a period boundary is crossed. Fall back to the EEG creation
-  // date so past billing periods stay selectable; EEGs with energy data are unaffected.
+  // periodsSelector derives the selectable range purely from energy metadata. That range
+  // is the wrong model for the billing period picker: billing is time-driven (you bill
+  // every period that has elapsed), so it must not be capped by where energy data happens
+  // to end. Two failure modes it caused: (1) an EEG with no energy data at all degenerated
+  // to "today"; (2) an EEG whose energy data is frozen in the past (e.g. the platform-fee
+  // EEG with a single stale record) only offered that old period. Fix: lower bound = energy
+  // start, or the EEG creation date when there is no energy data; upper bound = always the
+  // current period, so every quarter from the start up to today stays selectable.
   const effectivePeriods = useMemo(() => {
-    if (periods.end === "" && eeg?.createdAt) {
-      const begin = isoToDottedDate(eeg.createdAt);
-      if (begin) return {begin, end: ""};
-    }
-    return periods;
+    const hasEnergyData = periods.end !== "";
+    const begin = hasEnergyData
+      ? periods.begin
+      : (eeg?.createdAt ? isoToDottedDate(eeg.createdAt) : undefined);
+    if (!begin) return periods;
+    return {begin, end: todayDottedDate()};
   }, [periods, eeg?.createdAt]);
 
   return (


### PR DESCRIPTION
Follow-up to #88 / v1.0.8.

## Problem (surfaced in prod testing)
The billing period dropdown for `RC000000` still didn't offer Q2 2026. Root cause turned out to be different from the v1.0.8 assumption: `RC000000` is **not** truly energy-less — it has a single **stale energy metadata record from Q4 2022**. So `periods.end !== ""`, the v1.0.8 `createdAt` fallback never fired, and the range came from that one 2022 period → the dropdown showed only "Okt-Dez 2022" + the current quarter. Everything in between (2023 … Q2 2026) was missing.

## Fix
Billing is **time-driven**, so the period range must not be capped by where energy data ends. In `ParticipantPeriodHeaderComponent`:
- **upper bound = always the current period** (today), regardless of the latest energy period;
- **lower bound = energy start**, or `createdAt` when there is no energy data (v1.0.8 behaviour retained for genuinely empty EEGs).

EEGs with up-to-date energy data are unaffected (their latest period ≈ today already). EEGs with lagging/frozen data now additionally get the in-between periods up to today — desired for billing.

## Verification
- `tsc --noEmit` clean.
- Unit tests: 18/18 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)