### PR TITLE
docs(changelog): release v1.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ this changelog highlights the changes relevant for overview and operations.
 
 ## [Unreleased]
 
+## [1.0.9] – 2026-07-05
+
 ### Fixed
 - Billing period selector, follow-up to v1.0.8: the selectable range is no longer capped by
   where energy data ends. Billing is time-driven, but the range came straight from the energy


### PR DESCRIPTION
Stamp the billing-period upper-bound fix as **v1.0.9** (image `ghcr.io/vfeeg-development/vfeeg-web:v1.0.9` already crane-tagged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)