### PR TITLE
Show billing status timestamps in local time, not raw UTC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ this changelog highlights the changes relevant for overview and operations.
 
 ## [Unreleased]
 
+## [1.0.10] – 2026-07-06
+
 ### Changed
 - Billing run status label "Versendet" renamed to "Versand gestartet". The mails are handed to
   the mail relay (rate-limited, so they trickle out over time) — "Versendet" wrongly implied

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ this changelog highlights the changes relevant for overview and operations.
 
 ## [Unreleased]
 
+### Changed
+- Billing run status label "Versendet" renamed to "Versand gestartet". The mails are handed to
+  the mail relay (rate-limited, so they trickle out over time) — "Versendet" wrongly implied
+  they were already delivered. The reworded label reflects that the send was started, not that
+  delivery is confirmed.
+
 ### Fixed
 - Billing run "Versendet" / "Abgerechnet" timestamps showed the raw UTC time (2h early in
   summer). `reformatDateTimeStamp` sliced the naive timestamp string with no timezone

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ this changelog highlights the changes relevant for overview and operations.
 
 ## [Unreleased]
 
+### Fixed
+- Billing run "Versendet" / "Abgerechnet" timestamps showed the raw UTC time (2h early in
+  summer). `reformatDateTimeStamp` sliced the naive timestamp string with no timezone
+  conversion; billing sends these from `LocalDateTime.now()` in a UTC container. It now
+  interprets the value as UTC and renders it in the viewer's local time (DST-aware). Output
+  format unchanged.
+
 ## [1.0.9] – 2026-07-05
 
 ### Fixed

--- a/src/__test__/utils/Helper.util.test.ts
+++ b/src/__test__/utils/Helper.util.test.ts
@@ -1,5 +1,27 @@
 import { describe, it, expect } from "vitest";
-import {calc, determinePeriodEnd, getPeriodSegment, splitDate} from "../../util/Helper.util";
+import {calc, determinePeriodEnd, getPeriodSegment, reformatDateTimeStamp, splitDate} from "../../util/Helper.util";
+
+describe("reformatDateTimeStamp", () => {
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  const localOfUtc = (naive: string) => {
+    const d = new Date(naive + "Z");
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}, ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+  };
+
+  it("renders a naive billing (UTC) timestamp in local time, format 'YYYY-MM-DD, HH:mm'", () => {
+    // billing sends LocalDateTime.now() from a UTC container (no offset).
+    const input = "2026-07-05T17:26:00.000";
+    expect(reformatDateTimeStamp(input)).toMatch(/^\d{4}-\d{2}-\d{2}, \d{2}:\d{2}$/);
+    // interpreted as UTC, not sliced raw:
+    expect(reformatDateTimeStamp(input)).toBe(localOfUtc(input));
+  });
+
+  it("returns empty string for malformed / non-datetime input", () => {
+    expect(reformatDateTimeStamp("")).toBe("");
+    expect(reformatDateTimeStamp("2026-07-05")).toBe("");
+    expect(reformatDateTimeStamp("not-a-date")).toBe("");
+  });
+});
 
 describe("Helpers", () => {
   it("split date (dd.mm.yyyy HH:MM:SS", async () => {

--- a/src/components/participantPane/ParticipantPane.component.tsx
+++ b/src/components/participantPane/ParticipantPane.component.tsx
@@ -934,7 +934,7 @@ const ParticipantPaneComponent: FC = () => {
                     <>
                       <div>
                         {billingRun.mailStatus === "SENT"
-                          ? "Versendet (" +
+                          ? "Versand gestartet (" +
                           reformatDateTimeStamp(
                             billingRun.mailStatusDateTime
                           ) +

--- a/src/util/Helper.util.ts
+++ b/src/util/Helper.util.ts
@@ -265,7 +265,16 @@ export function findPartial<O extends object, OT extends keyof object>(obj: O, k
 // Kuerzt lange Timestampangaben. Z.B.: 2023-07-31T19:55:04.234769 -> 2023-07-31, 19:55
 export function reformatDateTimeStamp(dateTimeStampString : string) : string {
   if (dateTimeStampString && /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d*$/.test(dateTimeStampString)) {
-    return dateTimeStampString.substring(0,10)+", "+dateTimeStampString.substring(11,16)
+    // billing serialises these status timestamps from LocalDateTime.now() in a UTC container,
+    // i.e. a naive UTC wall-clock without offset. Interpret it as UTC and render in the
+    // viewer's local time instead of slicing the raw (UTC) string (which showed 2h early in
+    // summer). Output format unchanged: "YYYY-MM-DD, HH:mm".
+    const d = new Date(dateTimeStampString + "Z");
+    if (isNaN(d.getTime())) {
+      return dateTimeStampString.substring(0,10)+", "+dateTimeStampString.substring(11,16)
+    }
+    const pad = (n: number) => n.toString().padStart(2, "0");
+    return `${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())}, ${pad(d.getHours())}:${pad(d.getMinutes())}`
   } else {
     return "";
   }


### PR DESCRIPTION
## Problem
The billing run **"Versendet" / "Abgerechnet"** timestamps showed 2h early in summer (e.g. `17:26` for an action done at `19:26` local). Reported from prod.

`reformatDateTimeStamp` (`Helper.util.ts`) sliced the naive ISO string (`substring(11,16)`) with **no timezone conversion**. billing serialises these from `LocalDateTime.now()` in a **UTC container** (no offset), so the raw string is UTC → displayed as-is → −2h in summer / −1h in winter.

Root cause is a container-TZ inconsistency: the backend runs `TZ=Europe/Berlin` (its naive timestamps display correctly), billing runs UTC.

## Fix (web-only)
Interpret the naive value as UTC (`new Date(str + "Z")`) and render it in the **viewer's local time**, DST-aware. Output format unchanged (`YYYY-MM-DD, HH:mm`). Covers both usages (`mailStatusDateTime`, `runStatusDateTime`); the latent `sepaStatusDateTime` would be covered too if ever displayed.

Chosen over changing the billing container TZ (which would store local-naive — the fragile pattern that caused the earlier notification bug).

## Verification
- `tsc --noEmit` clean; 20/20 unit tests (2 new for `reformatDateTimeStamp`).
- Manual: summer `17:26Z` → `19:26`, winter `17:26Z` → `18:26`, midnight-cross `23:30Z` → next day `01:30`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
**Nachtrag (Support-Feedback):** Label „Versendet" → „**Versand gestartet**" umbenannt (gleiche Ansicht). „Versendet" suggerierte Zustellung; die Mails werden nur an den (rate-limitierten) Relay übergeben und tröpfeln raus. Commit `bad2978`.
