### PR TITLE
fix: Restore active-filter highlight on member view bottom buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ this changelog highlights the changes relevant for overview and operations.
 
 ## [Unreleased]
 
+### Fixed
+- Member view bottom filter buttons (person/consumption, producer/consumer) no longer showed the
+  active-filter highlight, so the selected filter was only inferrable from the result list. The
+  `.isActive` state set `--background` on an `IonButton` that defaults to `fill="clear"` inside
+  `IonButtons`, where the current Ionic (7.8.6) no longer paints it. The highlight now targets the
+  button's `::part(native)` with a real `background` (the pattern already used elsewhere, e.g.
+  `FilterSegment.component.scss`), so it renders regardless of the clear-button `--background`
+  handling. Visual/CSS-only — the filter logic is unchanged.
+
 ## [1.0.10] – 2026-07-06
 
 ### Changed

--- a/src/components/ButtonGroup.component.css
+++ b/src/components/ButtonGroup.component.css
@@ -18,7 +18,7 @@
 
 }
 
-.button-group-item.isActive {
-    --ion-text-color-rgb: 103, 103, 103;
-    --background: #C0E5E1;
+.button-group-item.isActive::part(native) {
+    background: #C0E5E1;
+    color: rgb(103, 103, 103);
 }


### PR DESCRIPTION
## Was

Der aktive Filter (Person/Blitz/Solar/Stecker) unten rechts in der Mitgliederansicht war nicht mehr hinterlegt — man sah nur an den Ergebnissen, welcher Filter aktiv ist. Gemeldet von einem Nutzer, in Dev reproduziert und **visuell bestätigt**.

## Ursache

Der `.isActive`-Zustand setzte `--background` auf einem `IonButton`, der in `IonButtons` per Default `fill="clear"` ist. Das aktuelle Ionic (7.8.6) malt `--background` auf clear-Buttons nicht mehr → kein sichtbares Highlight. Klassenlogik und Markup sind unverändert (seit 2023).

## Fix

Hintergrund direkt auf `::part(native)` setzen statt über `--background` — dasselbe Muster nutzt die App bereits (z. B. `FilterSegment.component.scss`). Reines CSS, Filterlogik unberührt. Blast-Radius: nur diese vier Buttons (`ButtonGroup` wird ausschließlich hier verwendet).

## Verifikation

In eegf-dev (preview-Deploy) visuell bestätigt: aktiver Button mint hinterlegt, Icon grau; Gegenklick entfernt die Hinterlegung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)