### PR TITLE
fix(deps): add events polyfill for xmlbuilder2 Node-builtin import

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "react-window": "^1.8.10",
     "recharts": "^2.10.3",
     "uuid": "^9.0.1",
+    "events": "^3.3.0",
     "xlsx": "^0.18.5",
     "xmlbuilder2": "^3.1.1"
   },


### PR DESCRIPTION
`xmlbuilder2` imports the Node built-in `events` module for its EventEmitter usage. Vite/Rollup since v3 do **not** polyfill Node built-ins automatically — without an npm `events` package, `EventEmitter` resolves to `undefined` and the bundle crashes at init with:

```
Uncaught TypeError: Class extends value undefined is not a constructor or null
```

Reproduced locally with puppeteer against a vite-built bundle: without this dep the app produces a white page. With `events@^3.3.0` bundled, the app boots clean.

The upstream [`events`](https://www.npmjs.com/package/events) package on npm is a small shim (~1KB gzipped) that provides the same EventEmitter API for browser bundles. No behaviour change for Node runtime.

## Discovered

While diffing gemeinstrom's fork against upstream during Fork-Cutover-Planning (2026-07-12). This was a bundle-init crash we hit repeatedly and only diagnosed correctly by tracing the resolve chain.

🤖 Prepared via Claude Code