### PR TITLE
fix(process): serialize activation as RFC3339 for time.Time backend field

### DIFF
--- a/src/components/processDetails/ProcessChangeParticipantFactor.component.tsx
+++ b/src/components/processDetails/ProcessChangeParticipantFactor.component.tsx
@@ -67,7 +67,7 @@ const ProcessChangeParticipantFactorComponent: FC<ProcessChangeParticipantFactor
       if (meter) {
         Api.eegService.changeMeterPartitionFactor(
           eeg.id.toUpperCase(),
-          meter.map(m => {return {meter: m.meteringPoint, direction: m.direction, gridOperatorId: m.gridOperatorId, activation: m.participantState.activeSince, partFact: data.partFact || 100}}))
+          meter.map(m => {return {meter: m.meteringPoint, direction: m.direction, gridOperatorId: m.gridOperatorId, activation: m.participantState.activeSince ? new Date(m.participantState.activeSince).toISOString() : new Date().toISOString(), partFact: data.partFact || 100}}))
           .finally(() => {
             reset()
           })

--- a/src/service/eeg.service.ts
+++ b/src/service/eeg.service.ts
@@ -422,7 +422,7 @@ export class EegService extends EegBaseService {
     }).then(this.handleErrors).then(res => res.json());
   }
 
-  async changeMeterPartitionFactor(tenant: string, meters: {meter: string, direction: MeterDirectionType, gridOperatorId: string, activation: Date, partFact: number}[]): Promise<any> {
+  async changeMeterPartitionFactor(tenant: string, meters: {meter: string, direction: MeterDirectionType, gridOperatorId: string, activation: string, partFact: number}[]): Promise<any> {
     const token = await this.lookupToken()
 
     const body = {meteringPoints: meters}


### PR DESCRIPTION
Backend's `ChangePartitionFactorRequest.Activation` is `time.Time` in Go, which strictly expects RFC3339. Frontend previously sent the bare `YYYY-MM-DD` date string from `participantState.activeSince`, which the Go decoder rejects with:

```
parsing time "2024-08-27" as "2006-01-02T15:04:05Z07:00":
  cannot parse "" as "T"
```

Surfacing as HTTP 400 with **no DB write and no EBMS dispatch to the grid operator**. This blocks any Teilnahmefaktor change.

## Two-part fix

1. `ProcessChangeParticipantFactor.component.tsx` — wrap `activeSince` in `new Date(...).toISOString()`. Fall back to today's date when activeSince is missing, so the form remains submittable for meters that lack an explicit activation date.
2. `eeg.service.ts` — `changeMeterPartitionFactor` signature accepts `activation: string` instead of `activation: Date` so the TypeScript build passes.

Discovered while diffing gemeinstrom's fork against upstream during Fork-Cutover-Planning (2026-07-12). Reproduced on the 2026-06-16 Teilnahmefaktor-99 %-change test-flow.

🤖 Prepared via Claude Code