### PR TITLE
feat: AGPL-3.0 §13 Quelltext-Link im Info-Footer

### DIFF
--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -304,7 +304,14 @@ const Menu: FC = () => {
           </IonContent>
           <IonFooter color="eeg">
             <IonItem lines="none" style={{fontSize: "12px", textAlign: "center"}}>
-              <IonLabel>eegFaktura ist eine freie und quelloffene Software und steht unter der AGPL</IonLabel>
+              <IonLabel className="ion-text-wrap">
+                eegFaktura ist freie, quelloffene Software unter der{" "}
+                <a href="https://www.gnu.org/licenses/agpl-3.0.html" target="_blank"
+                   rel="noopener noreferrer">AGPL-3.0</a>.{" "}
+                Quelltext (alle Komponenten):{" "}
+                <a href="https://github.com/eegfaktura" target="_blank"
+                   rel="noopener noreferrer">github.com/eegfaktura</a>
+              </IonLabel>
             </IonItem>
           </IonFooter>
         </IonModal>


### PR DESCRIPTION
Der Info/Impressum-Modal (`src/components/Menu.tsx`) nannte die AGPL, verlinkte aber **nicht den Quelltext**. AGPL-3.0 **§13** verlangt, dass Nutzer, die über das Netz mit der laufenden Anwendung interagieren, Zugang zum *Corresponding Source* erhalten.

**Fix (chirurgisch, nur der bestehende Footer):**
- Lizenz-Link → https://www.gnu.org/licenses/agpl-3.0.html
- Quelltext-Link → **https://github.com/eegfaktura** (die Org mit **allen** Komponenten-Repos der laufenden Suite — Frontend + backend + billing + energystore + … — nicht nur `eegfaktura-web`).

Relevant für die öffentlich erreichbaren Zonen mit echten Nutzern (Prod + kommende Pilot-Zone).

`pnpm exec vite build` grün. Reine UI-Text/Link-Änderung, keine Auth/Tenant/Endpoint-Fläche.

🤖 Generated with [Claude Code](https://claude.com/claude-code)