### PR TITLE
fix: Zählpunkt-Detail remountet beim ZP-Wechsel (stale toggle, #101)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ this changelog highlights the changes relevant for overview and operations.
 ## [Unreleased]
 
 ### Fixed
+- Metering-point detail pane could show the previous meter's active/inactive state after
+  switching between meters (stale render of the disabled `ion-toggle`, observed on
+  Safari/WebKit; text and toggle even contradicted each other). The meter detail block now
+  remounts per metering point via a React `key`, so every switch renders the selected
+  meter's real state (#101).
 - Member view bottom filter buttons (person/consumption, producer/consumer) no longer showed the
   active-filter highlight, so the selected filter was only inferrable from the result list. The
   `.isActive` state set `--background` on an `IonButton` that defaults to `fill="clear"` inside

--- a/src/components/participantPane/ParticipantDetailsPane.component.tsx
+++ b/src/components/participantPane/ParticipantDetailsPane.component.tsx
@@ -384,7 +384,9 @@ const ParticipantDetailsPaneComponent: FC = () => {
             </div>
             <div className={"details-box"}>
               {selectedMeter ? (
-                  <div className="ion-padding" slot="content">
+                  // key erzwingt Remount beim ZP-Wechsel — sonst behält die disabled
+                  // ion-toggle den Zustand des vorher gewählten ZP (Issue #101, Safari)
+                  <div className="ion-padding" slot="content" key={selectedMeter.meteringPoint}>
                     <IonToolbar color="primary">
                       <IonTitle>{formatMeteringPointString(selectedMeter.meteringPoint)}</IonTitle>
                       {isAdmin() && <IonButtons slot="end">


### PR DESCRIPTION
Fixes #101 — Ein-Zeilen-Fix: `key={selectedMeter.meteringPoint}` am Meter-Detail-Container erzwingt den Remount beim ZP-Wechsel; damit kann die disabled `ion-toggle` (Safari/WebKit) nicht mehr den Zustand des vorher gewählten ZP anzeigen. + CHANGELOG.

**Bewusst noch NICHT mergen:** Verifikation durch den Melder (Andreas, Safari) steht aus — und der freigegebene SEPA-Release soll diesen unverifizierten Fix nicht mitnehmen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)