### PR TITLE
fix: SEPA summarize uses gross amount for credit notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ this changelog highlights the changes relevant for overview and operations.
 ## [Unreleased]
 
 ### Fixed
+- SEPA export with "Mitglieder zusammenfassen" enabled booked the **net** amount for credit
+  notes (Gutschriften) instead of the **gross** amount, so payouts to VAT-liable producers were
+  short by the VAT. The summarize path (`summerizeSepaModel`) subtracted
+  `Rechnungsbetrag Netto` for non-invoice documents, while the non-summarize path and invoices
+  use `Rechnungsbetrag Brutto`. The checkbox is a pure per-IBAN aggregation and must not change
+  the amount basis; it now uses gross for credit notes too, matching the other path.
 - Member view bottom filter buttons (person/consumption, producer/consumer) no longer showed the
   active-filter highlight, so the selected filter was only inferrable from the result list. The
   `.isActive` state set `--background` on an `IonButton` that defaults to `fill="clear"` inside

--- a/src/service/sepa.converter.ts
+++ b/src/service/sepa.converter.ts
@@ -67,7 +67,7 @@ const summerizeSepaModel = async (rows: Record<string, Array<any>>) => {
         if (item['Dokumenttyp'] === 'Rechnung') {
           result.Amount += Number(item['Rechnungsbetrag Brutto'])
         } else {
-          result.Amount -= Number(item['Rechnungsbetrag Netto'])
+          result.Amount -= Number(item['Rechnungsbetrag Brutto'])
         }
         result.InvoiceIds.push(item['Nummer'])
 


### PR DESCRIPTION
Bei aktivem „Mitglieder zusammenfassen" wurde für Gutschriften der **Netto**-Betrag ins SEPA-File geschrieben statt **Brutto** → Auszahlungen an USt-pflichtige Erzeuger um die USt zu niedrig (z. B. 6,55 statt 7,40 bei 13 %). Fix: `summerizeSepaModel` nutzt wie der Nicht-Zusammenfassen-Pfad Brutto (1 Zeile) + CHANGELOG.

**In Dev seit 09.07., Verifikation durch Armin (pv-so.at) liegt vor → Release freigegeben (Operator 16.07.).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)