### PR TITLE
chore(release): v1.0.11 (SEPA-Brutto + Filter-Highlight)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ this changelog highlights the changes relevant for overview and operations.
 
 ## [Unreleased]
 
+## [1.0.11] – 2026-07-16
+
 ### Fixed
 - SEPA export with "Mitglieder zusammenfassen" enabled booked the **net** amount for credit
   notes (Gutschriften) instead of the **gross** amount, so payouts to VAT-liable producers were


### PR DESCRIPTION
CHANGELOG-Cut für **v1.0.11**: SEPA-Zusammenfassen bucht Gutschriften jetzt Brutto (#103, Armin-verifiziert) + Filter-Highlight-Fix (#94). Image `v1.0.11` = Digest `sha256:7dd2ad90…` (crane-Re-Tag von `sha-a4add93`, kein Rebuild).

🤖 Generated with [Claude Code](https://claude.com/claude-code)